### PR TITLE
Add semigroups to dependency for ghc < 8

### DIFF
--- a/z3.cabal
+++ b/z3.cabal
@@ -60,6 +60,8 @@ Library
     Build-depends:       base >= 4.5 && <5,
                          containers,
                          transformers >= 0.2
+    if impl(ghc < 8)
+      Build-depends:     semigroups >= 0.5
 
     Build-tools:         hsc2hs
     Extensions:          FlexibleInstances


### PR DESCRIPTION
`base < 4.9` does not export `Data.List.NonEmpty`