### PR TITLE
Replace z3_get_error_msg_ex with z3_get_error_msg

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -2498,7 +2498,7 @@ z3Error cd = throw . Z3Error cd
 checkError :: Ptr Z3_context -> IO a -> IO a
 checkError cPtr m = do
   m <* (z3_get_error_code cPtr >>= throwZ3Exn)
-  where getErrStr i  = peekCString =<< z3_get_error_msg_ex cPtr i
+  where getErrStr i  = peekCString =<< z3_get_error_msg i
         throwZ3Exn i = when (i /= z3_ok) $ getErrStr i >>= z3Error (toZ3Error i)
 
 ---------------------------------------------------------------------

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1453,10 +1453,6 @@ foreign import ccall unsafe "Z3_set_error"
 foreign import ccall unsafe "Z3_get_error_msg"
     z3_get_error_msg :: Z3_error_code -> IO Z3_string
 
--- | Reference: <http://z3prover.github.io/api/html/group__capi.html#gae0aba52b5738b2ea78e0d6ad67ef1f92>
-foreign import ccall unsafe "Z3_get_error_msg_ex"
-    z3_get_error_msg_ex :: Ptr Z3_context -> Z3_error_code -> IO Z3_string
-
 ---------------------------------------------------------------------
 -- * Miscellaneous
 


### PR DESCRIPTION
Fixes #20.

The `z3_get_error_msg_ex` function was removed from the Z3 C API for version 4.8.5 of Z3, which caused a linker error. This removes the references to `z3_get_error_msg_ex` and replaces them with `z3_get_error_msg` to fix that linker error.