### PR TITLE
Remove bindings to Z3_fixedpoint_push/pop.

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -387,8 +387,6 @@ module Z3.Base (
   -- * Fixedpoint
   , Fixedpoint (..)
   , mkFixedpoint
-  , fixedpointPush
-  , fixedpointPop
   , fixedpointAddRule
   , fixedpointSetParams
   , fixedpointRegisterRelation
@@ -2548,12 +2546,6 @@ instance Marshal Fixedpoint (Ptr Z3_fixedpoint) where
 
 mkFixedpoint :: Context -> IO Fixedpoint
 mkFixedpoint = liftFun0 z3_mk_fixedpoint
-
-fixedpointPush :: Context -> Fixedpoint -> IO ()
-fixedpointPush = liftFun1 z3_fixedpoint_push
-
-fixedpointPop :: Context -> Fixedpoint -> IO ()
-fixedpointPop = liftFun1 z3_fixedpoint_pop
 
 fixedpointAddRule :: Context -> Fixedpoint -> AST -> Symbol -> IO ()
 fixedpointAddRule = liftFun3 z3_fixedpoint_add_rule

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1466,12 +1466,6 @@ foreign import ccall unsafe "Z3_get_version"
 foreign import ccall unsafe "Z3_mk_fixedpoint"
     z3_mk_fixedpoint :: Ptr Z3_context -> IO (Ptr Z3_fixedpoint)
 
-foreign import ccall unsafe "Z3_fixedpoint_push"
-    z3_fixedpoint_push :: Ptr Z3_context -> Ptr Z3_fixedpoint -> IO ()
-
-foreign import ccall unsafe "Z3_fixedpoint_pop"
-    z3_fixedpoint_pop :: Ptr Z3_context -> Ptr Z3_fixedpoint -> IO ()
-
 foreign import ccall unsafe "Z3_fixedpoint_inc_ref"
     z3_fixedpoint_inc_ref :: Ptr Z3_context -> Ptr Z3_fixedpoint -> IO ()
 

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -344,8 +344,6 @@ module Z3.Monad
 
   -- * Fixedpoint
   , Fixedpoint
-  , fixedpointPush
-  , fixedpointPop
   , fixedpointAddRule
   , fixedpointSetParams
   , fixedpointRegisterRelation
@@ -2004,12 +2002,6 @@ getVersion = liftIO Base.getVersion
 
 class MonadZ3 m => MonadFixedpoint m where
   getFixedpoint :: m Base.Fixedpoint
-
-fixedpointPush :: MonadFixedpoint z3 => z3 ()
-fixedpointPush = liftFixedpoint0 Base.fixedpointPush
-
-fixedpointPop :: MonadFixedpoint z3 => z3 ()
-fixedpointPop = liftFixedpoint0 Base.fixedpointPush
 
 fixedpointAddRule :: MonadFixedpoint z3 => AST -> Symbol -> z3 ()
 fixedpointAddRule = liftFixedpoint2 Base.fixedpointAddRule


### PR DESCRIPTION
These were removed in Z3 version 4.8.5.

Fixes this issue: https://github.com/IagoAbal/haskell-z3/issues/22