### PR TITLE
Update arguments for Z3_get_error_msg to match Z3 (circa 4.8.7)

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -2496,7 +2496,7 @@ z3Error cd = throw . Z3Error cd
 checkError :: Ptr Z3_context -> IO a -> IO a
 checkError cPtr m = do
   m <* (z3_get_error_code cPtr >>= throwZ3Exn)
-  where getErrStr i  = peekCString =<< z3_get_error_msg i
+  where getErrStr i  = peekCString =<< z3_get_error_msg cPtr i
         throwZ3Exn i = when (i /= z3_ok) $ getErrStr i >>= z3Error (toZ3Error i)
 
 ---------------------------------------------------------------------

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1451,7 +1451,7 @@ foreign import ccall unsafe "Z3_set_error"
 
 -- | Reference: <http://z3prover.github.io/api/html/group__capi.html#gaf06357c49299efb8a0bdaeb3bc96c6d6>
 foreign import ccall unsafe "Z3_get_error_msg"
-    z3_get_error_msg :: Z3_error_code -> IO Z3_string
+    z3_get_error_msg :: Ptr Z3_context -> Z3_error_code -> IO Z3_string
 
 ---------------------------------------------------------------------
 -- * Miscellaneous


### PR DESCRIPTION
Hi @IagoAbal,

This change updates the previous fix for `Z3_get_error_msg` to supply the arguments needed by Z3.  This also fixes the tests, including https://github.com/IagoAbal/haskell-z3/issues/30.

Also, as noted by ocharles in that issue, I'm happy to help with cutting a release if you have a specified process and are willing to add me as a maintainer on Hackage.

