### PR TITLE
Expose z3_solver_get_proof as solverGetProof

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -412,6 +412,7 @@ module Z3.Base (
   , solverCheck
   , solverCheckAssumptions
   , solverGetModel
+  , solverGetProof
   , solverGetUnsatCore
   , solverGetReasonUnknown
   , solverToString
@@ -2784,6 +2785,14 @@ solverGetModel :: Context -> Solver -> IO Model
 solverGetModel ctx solver = marshal z3_solver_get_model ctx $ \f ->
   h2c solver $ \solverPtr ->
     f solverPtr
+
+-- | Retrieve the proof for the last 'solverCheck' or 'solverCheckAssumptions'.
+--
+-- The error handler is invoked if a proof is not available because
+-- the commands above were not invoked for the given solver,
+-- or if the result was different from 'Unsat' (so 'Sat' does not have a proof).
+solverGetProof :: Context -> Solver -> IO AST
+solverGetProof = liftFun1 z3_solver_get_proof
 
 -- | Retrieve the unsat core for the last 'solverCheckAssumptions'; the unsat core is a subset of the assumptions
 solverGetUnsatCore :: Context -> Solver -> IO [AST]

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1370,6 +1370,10 @@ foreign import ccall unsafe "Z3_solver_check_assumptions"
 foreign import ccall unsafe "Z3_solver_get_model"
     z3_solver_get_model :: Ptr Z3_context -> Ptr Z3_solver -> IO (Ptr Z3_model)
 
+-- | Reference: <http://z3prover.github.io/api/html/group__capi.html#gaba0fc4849eb0d1538d52aaa08f86a7c0>
+foreign import ccall unsafe "Z3_solver_get_proof"
+    z3_solver_get_proof :: Ptr Z3_context -> Ptr Z3_solver -> IO (Ptr Z3_ast)
+
 -- | Reference: <http://z3prover.github.io/api/html/group__capi.html#gabb4f8ed6a09873f5aeefe9cc01010864>
 foreign import ccall unsafe "Z3_solver_get_unsat_core"
     z3_solver_get_unsat_core :: Ptr Z3_context -> Ptr Z3_solver -> IO (Ptr Z3_ast_vector)

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -364,6 +364,7 @@ module Z3.Monad
   , solverCheck
   , solverCheckAssumptions
   , solverGetModel
+  , solverGetProof
   , solverGetUnsatCore
   , solverGetReasonUnknown
   , solverToString
@@ -2098,6 +2099,14 @@ solverCheckAssumptions = liftSolver1 Base.solverCheckAssumptions
 -- or if the result was 'Unsat'.
 solverGetModel :: MonadZ3 z3 => z3 Model
 solverGetModel = liftSolver0 Base.solverGetModel
+--
+-- | Retrieve the proof for the last 'solverCheck' or 'solverCheckAssumptions'.
+--
+-- The error handler is invoked if a proof is not available because
+-- the commands above were not invoked for the given solver,
+-- or if the result was different from 'Unsat' (so 'Sat' does not have a proof).
+solverGetProof :: MonadZ3 z3 => z3 AST
+solverGetProof = liftSolver0 Base.solverGetProof
 
 -- | Retrieve the unsat core for the last 'solverCheckAssumptions'; the unsat core is a subset of the assumptions
 solverGetUnsatCore :: MonadZ3 z3 => z3 [AST]


### PR DESCRIPTION
Hey @IagoAbal, looks like the function to get a proof of `Unsat` isn't exposed, so let's rectify this!