### PR TITLE
Fix issue#23: parseSMTLib2String now returns list of ASTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
+dist-newstyle
 .cabal-sandbox
 cabal.sandbox.config

--- a/examples/Example/Monad/ParserInterface.hs
+++ b/examples/Example/Monad/ParserInterface.hs
@@ -18,8 +18,8 @@ smtStr2 = "(declare-const x Int)\n(assert (> x 5))"
 
 script :: Z3 Result
 script = do
-  l <- parseSMTLib2String smtStr1 [] [] [] []
-  r <- parseSMTLib2String smtStr2 [] [] [] []
+  [l] <- parseSMTLib2String smtStr1 [] [] [] []
+  [r] <- parseSMTLib2String smtStr2 [] [] [] []
   eq <- mkEq l r
   assert l
   assert r

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -2702,7 +2702,7 @@ parseSMTLib2String :: Context
                    -> [Sort]     -- ^ sorts
                    -> [Symbol]   -- ^ declaration names
                    -> [FuncDecl] -- ^ declarations
-                   -> IO AST
+                   -> IO [AST]
 parseSMTLib2String ctx str sortNames sorts declNames decls =
   marshal z3_parse_smtlib2_string ctx $ \f ->
     withCString str $ \cstr ->
@@ -2718,7 +2718,7 @@ parseSMTLib2File :: Context
                  -> [Sort]     -- ^ sorts
                  -> [Symbol]   -- ^ declaration names
                  -> [FuncDecl] -- ^ declarations
-                 -> IO AST
+                 -> IO [AST]
 parseSMTLib2File ctx file sortNames sorts declNames decls =
   marshal z3_parse_smtlib2_string ctx $ \f ->
     withCString file $ \fileName ->

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1545,7 +1545,7 @@ foreign import ccall unsafe "Z3_parse_smtlib2_string"
                           -> CUInt
                           -> Ptr (Ptr Z3_symbol)
                           -> Ptr (Ptr Z3_func_decl)
-                          -> IO (Ptr Z3_ast)
+                          -> IO (Ptr Z3_ast_vector)
 
 -- | Referece <http://z3prover.github.io/api/html/group__capi.html#ga6168be4babb03fbbccff1fa7df451300>
 foreign import ccall unsafe "Z3_parse_smtlib2_file"

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -2264,7 +2264,7 @@ parseSMTLib2String :: MonadZ3 z3 =>
                    -> [Sort]     -- ^ sorts
                    -> [Symbol]   -- ^ declaration names
                    -> [FuncDecl] -- ^ declarations
-                   -> z3 AST
+                   -> z3 [AST]
 parseSMTLib2String = liftFun5 Base.parseSMTLib2String
 
 -- | Parse SMT expressions from a file
@@ -2276,7 +2276,7 @@ parseSMTLib2File :: MonadZ3 z3 =>
                  -> [Sort]     -- ^ sorts
                  -> [Symbol]   -- ^ declaration names
                  -> [FuncDecl] -- ^ declarations
-                 -> z3 AST
+                 -> z3 [AST]
 parseSMTLib2File = liftFun5 Base.parseSMTLib2File
 
 ---------------------------------------------------------------------

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@
 import Test.Hspec
 
 import qualified Z3.Base.Spec
+import qualified Z3.Regression
 
 main :: IO ()
 main = hspec spec
@@ -9,3 +10,4 @@ main = hspec spec
 spec :: Spec
 spec = do
   describe "Z3.Base" Z3.Base.Spec.spec
+  describe "Z3.Regression" Z3.Regression.spec

--- a/test/Z3/Regression.hs
+++ b/test/Z3/Regression.hs
@@ -1,0 +1,23 @@
+module Z3.Regression
+  ( spec )
+  where
+
+import Test.Hspec
+
+import Control.Monad(forM_)
+
+import qualified Z3.Base as Z3
+import qualified Z3.Monad
+
+spec :: Spec
+spec = do
+  describe "issue#23: Crash on parseSMTLib2String" $ do
+    it "should not crash" $
+      Z3.Monad.evalZ3 issue23script `shouldReturn` Z3.Monad.Unsat
+
+issue23script :: Z3.Monad.Z3 Z3.Monad.Result
+issue23script = do
+  asts <- Z3.Monad.parseSMTLib2String "(assert (= 1 2))" [] [] [] []
+  forM_ asts $ \ast -> do
+    Z3.Monad.assert ast
+  Z3.Monad.check

--- a/z3.cabal
+++ b/z3.cabal
@@ -130,7 +130,7 @@ Test-suite spec
     Main-is:            Spec.hs
 
     Other-modules:      Z3.Base.Spec
-						Z3.Regression
+                        Z3.Regression
 
     Build-depends:      base >= 4.5,
                         z3,

--- a/z3.cabal
+++ b/z3.cabal
@@ -130,6 +130,7 @@ Test-suite spec
     Main-is:            Spec.hs
 
     Other-modules:      Z3.Base.Spec
+						Z3.Regression
 
     Build-depends:      base >= 4.5,
                         z3,


### PR DESCRIPTION
As discovered in #23, there was a breaking change in Z3s parser interface not yet reflected in these bindings:

> A breaking change to the API is that parsers for SMT-LIB2 formulas return a vector of
> formulas as opposed to a conjunction of formulas. The vector of formulas correspond to
> the set of "assert" instructions in the SMT-LIB input.
> [https://github.com/Z3Prover/z3/releases/tag/z3-4.8.1](https://github.com/Z3Prover/z3/releases/tag/z3-4.8.1)

I only updated the corresponding function types to produce an `[AST]` since there already exists the required `Marshal` instance. I also added a small regression test, since there seemed to be no test covering parsing before. Are there any more modifications required?

---
Unrelated: My `cabal` version 3.2.0.0 builds into a directory called `dist-newstyle` which I additionally gitignored.