### PR TITLE
Fix issue 29: correct implementation of evalBv

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -340,7 +340,6 @@ module Z3.Base (
   , getBool
   , getInt
   , getReal
-  , getBv
 
   -- * Modifiers
   , substituteVars
@@ -2290,14 +2289,6 @@ getReal c a = parse <$> getNumeralString c a
         parseDen ('/':sj) = read sj
         parseDen _        = error "Z3.Base.getReal: no parse"
 
--- | Read the 'Integer' value from an 'AST' of sort /bit-vector/.
---
--- See 'mkBv2int'.
-getBv :: Context -> AST
-                 -> Bool  -- ^ signed?
-                 -> IO Integer
-getBv c a signed = getInt c =<< mkBv2int c a signed
-
 ---------------------------------------------------------------------
 -- Modifiers
 
@@ -2517,7 +2508,7 @@ evalReal ctx m ast = eval ctx m ast >>= T.traverse (getReal ctx)
 -- The flag /signed/ decides whether the bit-vector value is
 -- interpreted as a signed or unsigned integer.
 --
--- See 'modelEval' and 'getBv'.
+-- See 'modelEval' and 'mkBv2int'.
 evalBv :: Context -> Bool -- ^ signed?
                   -> EvalAst Integer
 evalBv ctx signed m ast =

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -2521,7 +2521,7 @@ evalReal ctx m ast = eval ctx m ast >>= T.traverse (getReal ctx)
 evalBv :: Context -> Bool -- ^ signed?
                   -> EvalAst Integer
 evalBv ctx signed m ast =
-  eval ctx m ast >>= T.traverse (\a -> getBv ctx a signed)
+  mkBv2int ctx ast signed >>= eval ctx m >>= T.traverse (\a -> getInt ctx a)
 
 -- | Evaluate a /collection/ of AST nodes in the given model.
 evalT :: Traversable t => Context -> Model -> t AST -> IO (Maybe (t AST))

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -297,7 +297,6 @@ module Z3.Monad
   , getBool
   , getInt
   , getReal
-  , getBv
 
   -- * Modifiers
   , substituteVars
@@ -1956,15 +1955,6 @@ getInt = liftFun1 Base.getInt
 getReal :: MonadZ3 z3 => AST -> z3 Rational
 getReal = liftFun1 Base.getReal
 
--- | Read the 'Integer' value from an 'AST' of sort /bit-vector/.
---
--- See 'mkBv2int'.
-getBv :: MonadZ3 z3 => AST
-                    -> Bool  -- ^ signed?
-                    -> z3 Integer
-getBv = liftFun2 Base.getBv
-
-
 ---------------------------------------------------------------------
 -- Modifiers
 
@@ -2139,7 +2129,7 @@ evalReal = liftFun2 Base.evalReal
 -- The flag /signed/ decides whether the bit-vector value is
 -- interpreted as a signed or unsigned integer.
 --
--- See 'modelEval' and 'getBv'.
+-- See 'modelEval' and 'mkBv2int'.
 evalBv :: MonadZ3 z3 => Bool -- ^ signed?
                      -> EvalAst z3 Integer
 evalBv = liftFun3 Base.evalBv

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -83,3 +83,12 @@ spec = around withContext $ do
         }
         in
       bad `shouldThrow` anyZ3Error
+
+    specify "evalBv" $ \ctx -> property $ \(i :: Integer) ->
+      monadicIO $ do
+        x <- run $ do
+          ast <- Z3.mkBitvector ctx 32 i
+          solver <- Z3.mkSolver ctx
+          (_, Just model) <- Z3.solverCheckAndGetModel ctx solver
+          Z3.evalBv ctx True model ast
+        assert $ x == Just i

--- a/test/Z3/Regression.hs
+++ b/test/Z3/Regression.hs
@@ -5,6 +5,7 @@ module Z3.Regression
 import Test.Hspec
 
 import Control.Monad(forM_)
+import Control.Monad.IO.Class
 
 import qualified Z3.Base as Z3
 import qualified Z3.Monad
@@ -15,9 +16,33 @@ spec = do
     it "should not crash" $
       Z3.Monad.evalZ3 issue23script `shouldReturn` Z3.Monad.Unsat
 
+  describe "issue#29: evalBv" $ do
+    it "should correctly evaluate example" $
+      Z3.Monad.evalZ3 issue29script `shouldReturn` Just 35
+
 issue23script :: Z3.Monad.Z3 Z3.Monad.Result
 issue23script = do
   asts <- Z3.Monad.parseSMTLib2String "(assert (= 1 2))" [] [] [] []
   forM_ asts $ \ast -> do
     Z3.Monad.assert ast
   Z3.Monad.check
+
+issue29script :: Z3.Monad.Z3 (Maybe Integer)
+issue29script = do
+  i32sort <- Z3.Monad.mkBvSort 32
+  let mkV name = do sym <- Z3.Monad.mkStringSymbol name
+                    Z3.Monad.mkVar sym i32sort
+
+  c <- Z3.Monad.mkBitvector 32 35
+  x <- mkV "x"
+
+  -- Perform some operations on the values
+  e  <- Z3.Monad.mkEq c x
+
+  Z3.Monad.assert e
+
+  z3result <- Z3.Monad.solverCheckAndGetModel
+  case z3result of
+    (Z3.Monad.Sat, Just model) -> Z3.Monad.evalBv True model x
+    _ -> return Nothing
+


### PR DESCRIPTION
Fixes #29, e.g. `evalBv`. As far as I can tell, the current implementation proceeds as follows:

1. Evaluate the given AST (`eval`)
2. Apply the conversion function from bit vector to Integer (`mkBv2int`)
3. Try to extract the Integer from the AST (`getInt`)

As a result, the conversion is never evaluated and the integer extraction fails because the AST node is a function application and not an integer. This PR swaps order of operations and adds the conversion function to the AST before evaluating it.

At least the example given in the issue works fine after this change.
