### PR TITLE
Add mkPow API

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -156,7 +156,7 @@ module Z3.Base (
   , mkDiv
   , mkMod
   , mkRem
-  , mkPow
+  , mkPower
   , mkLt
   , mkLe
   , mkGt
@@ -1130,8 +1130,8 @@ mkRem :: Context -> AST -> AST -> IO AST
 mkRem = liftFun2 z3_mk_rem
 
 -- | Create an AST node representing arg1 ^ arg2.
-mkPow :: Context -> AST -> AST -> IO AST
-mkPow = liftFun2 z3_mk_power
+mkPower :: Context -> AST -> AST -> IO AST
+mkPower = liftFun2 z3_mk_power
 
 -- | Create less than.
 mkLt :: Context -> AST -> AST -> IO AST

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -156,6 +156,7 @@ module Z3.Base (
   , mkDiv
   , mkMod
   , mkRem
+  , mkPow
   , mkLt
   , mkLe
   , mkGt
@@ -1128,7 +1129,9 @@ mkMod = liftFun2 z3_mk_mod
 mkRem :: Context -> AST -> AST -> IO AST
 mkRem = liftFun2 z3_mk_rem
 
--- TODO: Z3_mk_power
+-- | Create an AST node representing arg1 ^ arg2.
+mkPow :: Context -> AST -> AST -> IO AST
+mkPow = liftFun2 z3_mk_power
 
 -- | Create less than.
 mkLt :: Context -> AST -> AST -> IO AST

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -437,6 +437,10 @@ foreign import ccall unsafe "Z3_mk_mod"
 foreign import ccall unsafe "Z3_mk_rem"
     z3_mk_rem :: Ptr Z3_context -> Ptr Z3_ast -> Ptr Z3_ast ->  IO (Ptr Z3_ast)
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#ga8414506c805caa171f0c1fe29f9f9612>
+foreign import ccall unsafe "Z3_mk_power"
+    z3_mk_power :: Ptr Z3_context -> Ptr Z3_ast -> Ptr Z3_ast ->  IO (Ptr Z3_ast)
+
 -- | Reference: <http://z3prover.github.io/api/html/group__capi.html#ga58a3dc67c5de52cf599c346803ba1534>
 foreign import ccall unsafe "Z3_mk_lt"
     z3_mk_lt :: Ptr Z3_context -> Ptr Z3_ast -> Ptr Z3_ast ->  IO (Ptr Z3_ast)

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -113,7 +113,7 @@ module Z3.Monad
   , mkDiv
   , mkMod
   , mkRem
-  , mkPow
+  , mkPower
   , mkLt
   , mkLe
   , mkGt
@@ -1034,8 +1034,8 @@ mkRem = liftFun2 Base.mkRem
 -- | Create an AST node representing arg1 ^ arg2.
 --
 -- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga8414506c805caa171f0c1fe29f9f9612>
-mkPow :: MonadZ3 z3 => AST -> AST -> z3 AST
-mkPow = liftFun2 Base.mkPow
+mkPower :: MonadZ3 z3 => AST -> AST -> z3 AST
+mkPower = liftFun2 Base.mkPower
 
 -- | Create less than.
 --

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -113,6 +113,7 @@ module Z3.Monad
   , mkDiv
   , mkMod
   , mkRem
+  , mkPow
   , mkLt
   , mkLe
   , mkGt
@@ -1029,6 +1030,12 @@ mkMod = liftFun2 Base.mkMod
 -- Reference: <http://research.microsoft.com/en-us/um/redmond/projects/z3/group__capi.html#ga2fcdb17f9039bbdaddf8a30d037bd9ff>
 mkRem :: MonadZ3 z3 => AST -> AST -> z3 AST
 mkRem = liftFun2 Base.mkRem
+
+-- | Create an AST node representing arg1 ^ arg2.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga8414506c805caa171f0c1fe29f9f9612>
+mkPow :: MonadZ3 z3 => AST -> AST -> z3 AST
+mkPow = liftFun2 Base.mkPow
 
 -- | Create less than.
 --

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -52,12 +52,12 @@ spec = around withContext $ do
           Z3.getInt ctx ast;
         assert $ x == i
 
-    specify "mkPow" $ \ctx -> property $ \(ValidPowerInput i j) ->
+    specify "mkPower" $ \ctx -> property $ \(ValidPowerInput i j) ->
       monadicIO $ do
         x <- run $ do
           iAst <- Z3.mkInteger ctx i
           jAst <- Z3.mkInteger ctx j
-          p <- Z3.mkPow ctx iAst jAst
+          p <- Z3.mkPower ctx iAst jAst
           sol <- Z3.mkSolver ctx
           (_, Just model) <- Z3.solverCheckAndGetModel ctx sol
           Z3.evalInt ctx model p 

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -5,7 +5,8 @@ module Z3.Base.Spec
   where
 
 import Test.Hspec
-import Test.QuickCheck ( property )
+import Test.QuickCheck ( property, choose )
+import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Monadic
 
 import qualified Z3.Base as Z3
@@ -17,6 +18,18 @@ withContext k = do
 
 anyZ3Error :: Selector Z3.Z3Error
 anyZ3Error = const True
+
+data ValidPowerInput = ValidPowerInput Integer Integer
+  deriving Show
+
+instance Arbitrary ValidPowerInput where
+  arbitrary = do i <- choose (0::Integer, 10)
+                 j <- choose (0::Integer, 64)
+                 return $ ValidPowerInput i j
+
+z3powerDef :: Integer -> Integer -> Integer
+z3powerDef 0 0 = 0
+z3powerDef i j = i ^ j
 
 spec :: Spec
 spec = around withContext $ do
@@ -38,6 +51,17 @@ spec = around withContext $ do
           ast <- Z3.mkInteger ctx i;
           Z3.getInt ctx ast;
         assert $ x == i
+
+    specify "mkPow" $ \ctx -> property $ \(ValidPowerInput i j) ->
+      monadicIO $ do
+        x <- run $ do
+          iAst <- Z3.mkInteger ctx i
+          jAst <- Z3.mkInteger ctx j
+          p <- Z3.mkPow ctx iAst jAst
+          sol <- Z3.mkSolver ctx
+          (_, Just model) <- Z3.solverCheckAndGetModel ctx sol
+          Z3.evalInt ctx model p 
+        assert $ x == Just (z3powerDef i j)
 
   context "AST Equality and Substitution" $ do
     specify "isEqAST" $ \ctx ->


### PR DESCRIPTION
This adds support for the `z3_mk_power` API function. Two interesting things:

1. In Z3 evaluation `0 ^ 0 = 0`, so it does not behave identical to `^` in Haskell where `0 ^ 0 = 1`.

2. For some reason I could not yet figure out, Z3 only evaluates powers up to a certain size and returns the unevaluated AST afterwards. The smallest example I found with QuickCheck was `2 ^ 65`. Thus I arbitrarily (*pun intended*) generate test inputs up to `10^64` which seems to work fine. I could not find any documentation for this behavior, so in case you don't know more either I could ask on the Z3 issue tracker directly.

Also I saw that the documentation links are outdated and will update them.