### PR TITLE
Add wrapper type for tuple sorts

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -110,6 +110,10 @@ module Z3.Base (
   , mkFiniteDomainSort
   , mkArraySort
   , mkTupleSort
+  , mkTupleType
+  , mkTuple
+  , mkIndexTuple
+  , mkProjTuple
   , mkConstructor
   , mkDatatype
   , mkDatatypes
@@ -874,13 +878,14 @@ mkTuple :: Context -> TupleType -> [AST] -> IO AST
 mkTuple ctx TupleType{tupleCons} args = mkApp ctx tupleCons args
 
 -- | Project the i-th field of the given tuple,
-indexTuple :: Context -> TupleType -> Int -> AST -> IO AST
-indexTuple ctx tt i tup
+mkIndexTuple :: Context -> TupleType -> Int -> AST -> IO AST
+mkIndexTuple ctx tt i tup
   | 0 <= i && i < length (tupleProjs tt) = mkApp ctx (tupleProjs tt !! i) [tup]
   | otherwise                            = error "Invalid tuple index used."
 
-projTuple :: Context -> TupleType -> String -> AST -> IO AST
-projTuple ctx TupleType{namedTupleProjs} f tup = case lookup f namedTupleProjs of
+-- | Project a field of the given tuple by name,
+mkProjTuple :: Context -> TupleType -> String -> AST -> IO AST
+mkProjTuple ctx TupleType{namedTupleProjs} f tup = case lookup f namedTupleProjs of
   Just proj -> mkApp ctx proj [tup]
   Nothing   -> error "Invalid tuple field used."
 

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -464,6 +464,7 @@ import Z3.Base
   ( Symbol
   , AST
   , Sort
+  , TupleSort
   , FuncDecl
   , App
   , Pattern
@@ -769,9 +770,7 @@ mkArraySort = liftFun2 Base.mkArraySort
 mkTupleSort :: MonadZ3 z3
             => Symbol                          -- ^ Name of the sort
             -> [(Symbol, Sort)]                -- ^ Name and sort of each field
-            -> z3 (Sort, FuncDecl, [FuncDecl]) -- ^ Resulting sort, and function
-                                               -- declarations for the
-                                               -- constructor and projections.
+            -> z3 TupleSort                    -- ^ Resulting sort with functions
 mkTupleSort = liftFun2 Base.mkTupleSort
 
 -- | Create a constructor

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -464,7 +464,7 @@ import Z3.Base
   ( Symbol
   , AST
   , Sort
-  , TupleSort
+  , TupleType
   , FuncDecl
   , App
   , Pattern
@@ -770,7 +770,9 @@ mkArraySort = liftFun2 Base.mkArraySort
 mkTupleSort :: MonadZ3 z3
             => Symbol                          -- ^ Name of the sort
             -> [(Symbol, Sort)]                -- ^ Name and sort of each field
-            -> z3 TupleSort                    -- ^ Resulting sort with functions
+            -> z3 (Sort, FuncDecl, [FuncDecl]) -- ^ Resulting sort, and function
+                                               -- declarations for the
+                                               -- constructor and projections.
 mkTupleSort = liftFun2 Base.mkTupleSort
 
 -- | Create a constructor


### PR DESCRIPTION
This is a simple approach to creating a separate Haskell type for tuple sorts, as was described in a TODO (see diff).

But I am not sure if the naming is good, because I intuitively wanted to use a `TupleSort` as a `Sort` in the tests. I automatically assumed some form of subtype relation and not a wrapping-around relation. Well, maybe the name `TupleType` as in the original comment is better after all. But then you use `mkTupleSort` to get a `TupleType` which is also suboptimal imo.