### PR TITLE
Extend quantifier API to support user specified weights

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -1839,17 +1839,19 @@ type MkZ3Quantifier = Ptr Z3_context -> CUInt
 -- TODO: Allow the user to specify the quantifier weight!
 marshalMkQ :: MkZ3Quantifier
           -> Context
+          -> Int
           -> [Pattern]
           -> [Symbol]
           -> [Sort]
           -> AST
           -> IO AST
-marshalMkQ z3_mk_Q ctx pats x s body = marshal z3_mk_Q ctx $ \f ->
+marshalMkQ z3_mk_Q ctx weight pats x s body = marshal z3_mk_Q ctx $ \f ->
   marshalArrayLen pats $ \n patsArr ->
   marshalArray x $ \xArr ->
   marshalArray s $ \sArr ->
+  h2c weight $ \weightC ->
   h2c body $ \bodyPtr ->
-    f 0 n patsArr len sArr xArr bodyPtr
+    f weightC n patsArr len sArr xArr bodyPtr
   where len
           | l == 0        = error "Z3.Base.mkQuantifier:\
               \ quantifier with 0 bound variables"
@@ -1866,6 +1868,7 @@ marshalMkQ z3_mk_Q ctx pats x s body = marshal z3_mk_Q ctx $ \f ->
 -- variable with index 0, the second to last element of /xs/ refers to the
 -- variable with index 1, etc.
 mkForall :: Context
+          -> Int        -- ^ quantifiers are associated with weights indicating the importance of using the quantifier during instantiation. By default, pass the weight 0.
           -> [Pattern]  -- ^ Instantiation patterns (see 'mkPattern').
           -> [Symbol]   -- ^ Bound (quantified) variables /xs/.
           -> [Sort]     -- ^ Sorts of the bound variables.
@@ -1876,7 +1879,7 @@ mkForall = marshalMkQ z3_mk_forall
 -- | Create an exists formula.
 --
 -- Similar to 'mkForall'.
-mkExists :: Context -> [Pattern] -> [Symbol] -> [Sort] -> AST -> IO AST
+mkExists :: Context -> Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> IO AST
 mkExists = marshalMkQ z3_mk_exists
 
 -- TODO: Z3_mk_quantifier
@@ -1893,26 +1896,29 @@ type MkZ3QuantifierConst = Ptr Z3_context
 
 marshalMkQConst :: MkZ3QuantifierConst
                   -> Context
+                  -> Int
                   -> [Pattern]
                   -> [App]
                   -> AST
                 -> IO AST
-marshalMkQConst z3_mk_Q_const ctx pats apps body =
+marshalMkQConst z3_mk_Q_const ctx weight pats apps body =
   marshal z3_mk_Q_const ctx $ \f ->
     marshalArrayLen pats $ \patsNum patsArr ->
     marshalArray    apps $ \appsArr ->
+    h2c weight $ \weightC ->
     h2c body $ \bodyPtr ->
-      f 0 len appsArr patsNum patsArr bodyPtr
+      f weightC len appsArr patsNum patsArr bodyPtr
   where len
           | l == 0        = error "Z3.Base.mkQuantifierConst:\
               \ quantifier with 0 bound variables"
           | otherwise     = fromIntegral l
           where l = length apps
--- TODO: Allow the user to specify the quantifier weight!
 
 -- | Create a universal quantifier using a list of constants that will form the
 -- set of bound variables.
 mkForallConst :: Context
+              -> Int       -- ^ quantifiers are associated with weights indicating the importance of using the quantifier during instantiation. By default, pass the weight 0.
+
               -> [Pattern] -- ^ Instantiation patterns (see 'mkPattern').
               -> [App]     -- ^ Constants to be abstracted into bound variables.
               -> AST       -- ^ Quantifier body.
@@ -1922,6 +1928,7 @@ mkForallConst = marshalMkQConst z3_mk_forall_const
 -- | Create a existential quantifier using a list of constants that will form
 -- the set of bound variables.
 mkExistsConst :: Context
+              -> Int       -- ^ quantifiers are associated with weights indicating the importance of using the quantifier during instantiation. By default, pass the weight 0.
               -> [Pattern] -- ^ Instantiation patterns (see 'mkPattern').
               -> [App]     -- ^ Constants to be abstracted into bound variables.
               -> AST       -- ^ Quantifier body.

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -292,9 +292,13 @@ module Z3.Base (
   , mkPattern
   , mkBound
   , mkForall
+  , mkForallW
   , mkExists
+  , mkExistsW
   , mkForallConst
+  , mkForallWConst
   , mkExistsConst
+  , mkExistsWConst
 
   -- * Accessors
   , getSymbolString
@@ -1859,6 +1863,14 @@ marshalMkQ z3_mk_Q ctx weight pats x s body = marshal z3_mk_Q ctx $ \f ->
               \ different number of symbols and sorts"
           | otherwise     = fromIntegral l
           where l = length s
+-- | 'mkForall' with weight 0 (the default).
+mkForall :: Context
+          -> [Pattern]  -- ^ Instantiation patterns (see 'mkPattern').
+          -> [Symbol]   -- ^ Bound (quantified) variables /xs/.
+          -> [Sort]     -- ^ Sorts of the bound variables.
+          -> AST        -- ^ Body of the quantifier.
+          -> IO AST
+mkForall = flip mkForallW 0
 
 -- | Create a forall formula.
 --
@@ -1867,20 +1879,25 @@ marshalMkQ z3_mk_Q ctx weight pats x s body = marshal z3_mk_Q ctx $ \f ->
 -- Z3 applies the convention that the last element in /xs/ refers to the
 -- variable with index 0, the second to last element of /xs/ refers to the
 -- variable with index 1, etc.
-mkForall :: Context
+mkForallW :: Context
           -> Int        -- ^ quantifiers are associated with weights indicating the importance of using the quantifier during instantiation. By default, pass the weight 0.
           -> [Pattern]  -- ^ Instantiation patterns (see 'mkPattern').
           -> [Symbol]   -- ^ Bound (quantified) variables /xs/.
           -> [Sort]     -- ^ Sorts of the bound variables.
           -> AST        -- ^ Body of the quantifier.
           -> IO AST
-mkForall = marshalMkQ z3_mk_forall
+mkForallW = marshalMkQ z3_mk_forall
+
 
 -- | Create an exists formula.
 --
--- Similar to 'mkForall'.
-mkExists :: Context -> Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> IO AST
-mkExists = marshalMkQ z3_mk_exists
+-- Similar to 'mkForallW'.
+mkExistsW :: Context -> Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> IO AST
+mkExistsW = marshalMkQ z3_mk_exists
+
+-- | `mkExistsW` with weight 0 (the default).
+mkExists :: Context -> [Pattern] -> [Symbol] -> [Sort] -> AST -> IO AST
+mkExists = flip mkExistsW 0
 
 -- TODO: Z3_mk_quantifier
 -- TODO: Z3_mk_quantifier_ex
@@ -1916,24 +1933,33 @@ marshalMkQConst z3_mk_Q_const ctx weight pats apps body =
 
 -- | Create a universal quantifier using a list of constants that will form the
 -- set of bound variables.
-mkForallConst :: Context
+mkForallWConst :: Context
               -> Int       -- ^ quantifiers are associated with weights indicating the importance of using the quantifier during instantiation. By default, pass the weight 0.
 
               -> [Pattern] -- ^ Instantiation patterns (see 'mkPattern').
               -> [App]     -- ^ Constants to be abstracted into bound variables.
               -> AST       -- ^ Quantifier body.
               -> IO AST
-mkForallConst = marshalMkQConst z3_mk_forall_const
+mkForallWConst = marshalMkQConst z3_mk_forall_const
+
+
+-- | 'mkForallWConst' with weight set to 0 (the default).
+mkForallConst :: Context -> [Pattern] -> [App] -> AST -> IO AST
+mkForallConst = flip mkForallWConst 0
 
 -- | Create a existential quantifier using a list of constants that will form
 -- the set of bound variables.
-mkExistsConst :: Context
+mkExistsWConst :: Context
               -> Int       -- ^ quantifiers are associated with weights indicating the importance of using the quantifier during instantiation. By default, pass the weight 0.
               -> [Pattern] -- ^ Instantiation patterns (see 'mkPattern').
               -> [App]     -- ^ Constants to be abstracted into bound variables.
               -> AST       -- ^ Quantifier body.
               -> IO AST
-mkExistsConst = marshalMkQConst z3_mk_exists_const
+mkExistsWConst = marshalMkQConst z3_mk_exists_const
+
+-- | 'mkForallWConst' with weight set to 0 (the default).
+mkExistsConst :: Context -> [Pattern] -> [App] -> AST -> IO AST
+mkExistsConst = flip mkExistsWConst 0
 
 -- TODO: Z3_mk_quantifier_const
 -- TODO: Z3_mk_quantifier_const_ex

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -1764,17 +1764,17 @@ mkPattern = liftFun1 Base.mkPattern
 mkBound :: MonadZ3 z3 => Int -> Sort -> z3 AST
 mkBound = liftFun2 Base.mkBound
 
-mkForall :: MonadZ3 z3 => [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
-mkForall = liftFun4 Base.mkForall
+mkForall :: MonadZ3 z3 => Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
+mkForall = liftFun5 Base.mkForall
 
-mkForallConst :: MonadZ3 z3 => [Pattern] -> [App] -> AST -> z3 AST
-mkForallConst = liftFun3 Base.mkForallConst
+mkForallConst :: MonadZ3 z3 => Int -> [Pattern] -> [App] -> AST -> z3 AST
+mkForallConst = liftFun4 Base.mkForallConst
 
-mkExistsConst :: MonadZ3 z3 => [Pattern] -> [App] -> AST -> z3 AST
-mkExistsConst = liftFun3 Base.mkExistsConst
+mkExistsConst :: MonadZ3 z3 => Int -> [Pattern] -> [App] -> AST -> z3 AST
+mkExistsConst = liftFun4 Base.mkExistsConst
 
-mkExists :: MonadZ3 z3 => [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
-mkExists = liftFun4 Base.mkExists
+mkExists :: MonadZ3 z3 => Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
+mkExists = liftFun5 Base.mkExists
 
 ---------------------------------------------------------------------
 -- Accessors

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -249,9 +249,13 @@ module Z3.Monad
   , mkPattern
   , mkBound
   , mkForall
+  , mkForallW
   , mkExists
+  , mkExistsW
   , mkForallConst
+  , mkForallWConst
   , mkExistsConst
+  , mkExistsWConst
 
   -- * Accessors
   , getSymbolString
@@ -1764,17 +1768,29 @@ mkPattern = liftFun1 Base.mkPattern
 mkBound :: MonadZ3 z3 => Int -> Sort -> z3 AST
 mkBound = liftFun2 Base.mkBound
 
-mkForall :: MonadZ3 z3 => Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
-mkForall = liftFun5 Base.mkForall
+mkForallW :: MonadZ3 z3 => Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
+mkForallW = liftFun5 Base.mkForallW
 
-mkForallConst :: MonadZ3 z3 => Int -> [Pattern] -> [App] -> AST -> z3 AST
-mkForallConst = liftFun4 Base.mkForallConst
+mkForall :: MonadZ3 z3 => [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
+mkForall = liftFun4 Base.mkForall
 
-mkExistsConst :: MonadZ3 z3 => Int -> [Pattern] -> [App] -> AST -> z3 AST
-mkExistsConst = liftFun4 Base.mkExistsConst
+mkForallConst :: MonadZ3 z3 => [Pattern] -> [App] -> AST -> z3 AST
+mkForallConst = liftFun3 Base.mkForallConst
 
-mkExists :: MonadZ3 z3 => Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
-mkExists = liftFun5 Base.mkExists
+mkForallWConst :: MonadZ3 z3 => Int -> [Pattern] -> [App] -> AST -> z3 AST
+mkForallWConst = liftFun4 Base.mkForallWConst
+
+mkExistsConst :: MonadZ3 z3 => [Pattern] -> [App] -> AST -> z3 AST
+mkExistsConst = liftFun3 Base.mkExistsConst
+
+mkExistsWConst :: MonadZ3 z3 => Int -> [Pattern] -> [App] -> AST -> z3 AST
+mkExistsWConst = liftFun4 Base.mkExistsWConst
+
+mkExistsW :: MonadZ3 z3 => Int -> [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
+mkExistsW = liftFun5 Base.mkExistsW
+
+mkExists :: MonadZ3 z3 => [Pattern] -> [Symbol] -> [Sort] -> AST -> z3 AST
+mkExists = liftFun4 Base.mkExists
 
 ---------------------------------------------------------------------
 -- Accessors

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -116,3 +116,39 @@ spec = around withContext $ do
           (_, Just model) <- Z3.solverCheckAndGetModel ctx solver
           Z3.evalBv ctx True model ast
         assert $ x == Just i
+
+  context "Quantifiers" $ do
+
+    specify "mkForall" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        fa <- Z3.mkForall ctx 554 [] [x] [int] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 554
+
+    specify "mkExists" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        fa <- Z3.mkExists ctx 10 [] [x] [int] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 10
+
+    specify "mkForallConst" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        v <- Z3.toApp ctx =<< Z3.mkConst ctx x int
+        fa <- Z3.mkForallConst ctx 554 [] [v] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 554
+
+    specify "mkExistsConst" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        v <- Z3.toApp ctx =<< Z3.mkConst ctx x int
+        fa <- Z3.mkExistsConst ctx 991 [] [v] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 991

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -119,36 +119,70 @@ spec = around withContext $ do
 
   context "Quantifiers" $ do
 
+    specify "mkForallW" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        fa <- Z3.mkForallW ctx 554 [] [x] [int] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 554
+
     specify "mkForall" $ \ctx ->
       (do
         int <- Z3.mkIntSort ctx
         x <- Z3.mkStringSymbol ctx "x"
-        fa <- Z3.mkForall ctx 554 [] [x] [int] =<< Z3.mkBool ctx True
+        fa <- Z3.mkForall ctx [] [x] [int] =<< Z3.mkBool ctx True
         Z3.getQuantifierWeight ctx fa
-      ) `shouldReturn` 554
+      ) `shouldReturn` 0
+
+    specify "mkExistsW" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        fa <- Z3.mkExistsW ctx 37 [] [x] [int] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 37
 
     specify "mkExists" $ \ctx ->
       (do
         int <- Z3.mkIntSort ctx
         x <- Z3.mkStringSymbol ctx "x"
-        fa <- Z3.mkExists ctx 10 [] [x] [int] =<< Z3.mkBool ctx True
+        fa <- Z3.mkExists ctx [] [x] [int] =<< Z3.mkBool ctx True
         Z3.getQuantifierWeight ctx fa
-      ) `shouldReturn` 10
+      ) `shouldReturn` 0
+
+    specify "mkForallWConst" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        v <- Z3.toApp ctx =<< Z3.mkConst ctx x int
+        fa <- Z3.mkForallWConst ctx 554 [] [v] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 554
 
     specify "mkForallConst" $ \ctx ->
       (do
         int <- Z3.mkIntSort ctx
         x <- Z3.mkStringSymbol ctx "x"
         v <- Z3.toApp ctx =<< Z3.mkConst ctx x int
-        fa <- Z3.mkForallConst ctx 554 [] [v] =<< Z3.mkBool ctx True
+        fa <- Z3.mkForallConst ctx [] [v] =<< Z3.mkBool ctx True
         Z3.getQuantifierWeight ctx fa
-      ) `shouldReturn` 554
+      ) `shouldReturn` 0
+
+    specify "mkExistsWConst" $ \ctx ->
+      (do
+        int <- Z3.mkIntSort ctx
+        x <- Z3.mkStringSymbol ctx "x"
+        v <- Z3.toApp ctx =<< Z3.mkConst ctx x int
+        fa <- Z3.mkExistsWConst ctx 991 [] [v] =<< Z3.mkBool ctx True
+        Z3.getQuantifierWeight ctx fa
+      ) `shouldReturn` 991
 
     specify "mkExistsConst" $ \ctx ->
       (do
         int <- Z3.mkIntSort ctx
         x <- Z3.mkStringSymbol ctx "x"
         v <- Z3.toApp ctx =<< Z3.mkConst ctx x int
-        fa <- Z3.mkExistsConst ctx 991 [] [v] =<< Z3.mkBool ctx True
+        fa <- Z3.mkExistsConst ctx [] [v] =<< Z3.mkBool ctx True
         Z3.getQuantifierWeight ctx fa
-      ) `shouldReturn` 991
+      ) `shouldReturn` 0


### PR DESCRIPTION
Currently quantifiers are always built with the default weight 0, this PR extends the quantifier constructors with an argument for the weight.