### PR TITLE
Add support for recursive functions by supporting new Z3 API functions Z3_mk_rec_func_decl and Z3_add_rec_def

### DIFF
--- a/examples/Example/Monad/IntList.hs
+++ b/examples/Example/Monad/IntList.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Example.Monad.IntList where
+
+import Z3.Monad
+import Control.Monad.IO.Class (liftIO)
+
+run :: IO ()
+run = evalZ3 datatypeScript
+
+mkIntListDatatype :: Z3 Sort
+mkIntListDatatype = do
+
+  intS <- mkIntSort
+  
+  -- nil constructor
+  nil <- mkStringSymbol "nil"
+  isNil <- mkStringSymbol "is_nil"
+
+  -- cons constructors
+  hd <- mkStringSymbol "hd"
+  tl <- mkStringSymbol "tl"
+  cons <- mkStringSymbol "cons"
+  isCons <- mkStringSymbol "is_cons"
+
+  nilCons <- mkConstructor nil isNil []
+  consCons <- mkConstructor cons isCons [ (hd, Just intS, 0), (tl, Nothing, 0) ]
+
+  intList <- mkStringSymbol "IntList"
+  
+  mkDatatype intList [nilCons, consCons]
+
+printFuncs :: [FuncDecl] -> Z3 ()
+printFuncs = mapM_ (\c -> getDeclName c >>= getSymbolString >>=
+                          liftIO. putStrLn)
+
+datatypeScript :: Z3 ()
+datatypeScript = do
+
+  intList <- mkIntListDatatype
+
+  [nilC, consC] <- getDatatypeSortConstructors intList
+  [nilR, consR] <- getDatatypeSortRecognizers intList
+  [[],[hdA, tlA]] <- getDatatypeSortConstructorAccessors intList
+  
+  
+  liftIO $ putStrLn "*** List constructors are named"
+  printFuncs [nilC, consC]
+  liftIO $ putStrLn "*** List recognizers are named"
+  printFuncs [nilR, consR]
+
+  liftIO $ putStrLn "*** List accessors are named"
+  printFuncs [hdA, tlA]
+
+  let listToAST [] = mkApp nilC []
+      listToAST (n:ns) = do
+        ns' <- listToAST ns
+        nn <- mkInteger n
+        mkApp consC [ nn, ns' ]
+
+  nil <- mkApp nilC []
+  fortyTwo <- mkInteger 42
+  fiftySeven <- mkInteger 57
+  l1 <- mkApp consC [ fortyTwo, nil]
+  l2 <- mkApp consC [ fiftySeven, nil]
+
+  eightyTwo <- mkInteger 82
+  l3 <- mkApp consC [ eightyTwo, l1]
+  l4 <- mkApp consC [ eightyTwo, l2]
+  
+  push
+
+  liftIO $ putStrLn "*** Is nil != cons 42 nil?  Expect Unsat"
+  
+  p <- mkNot =<< mkEq nil l1
+  mkNot p >>= assert
+  
+  -- solverToString >>= liftIO . putStr
+
+  check >>= liftIO . print
+
+  pop 1
+
+
+  push
+
+  liftIO $ putStrLn "*** list-equiv test"
+
+  boolS <- mkBoolSort
+
+  listEquivSym <- mkStringSymbol "list-equiv"
+
+  listEquivF <- mkRecFuncDecl listEquivSym [intList, intList] boolS
+  l1s <- mkFreshConst "l1a" intList
+  l2s <- mkFreshConst "l2a" intList
+
+  rnil1 <- mkApp nilR [l1s]
+  rnil2 <- mkApp nilR [l2s]
+
+  nilPred <- mkAnd [rnil1, rnil2]
+
+  rcons1 <- mkApp consR [l1s]
+  rcons2 <- mkApp consR [l2s]
+  hd1 <- mkApp hdA [l1s]
+  hd2 <- mkApp hdA [l2s]
+  hdeq <- mkEq hd1 hd2
+  tl1 <- mkApp tlA [l1s]
+  tl2 <- mkApp tlA [l2s]
+  tlequiv <- mkApp listEquivF [tl1, tl2]
+
+  consPred <- mkAnd [rcons1, rcons2, hdeq, tlequiv]
+
+  equivBody <- mkOr [nilPred, consPred]
+
+  addRecDef listEquivF [l1s, l2s] equivBody
+
+  let twoListsEquiv l1 l2 = do
+        liftIO $ putStrLn $ "*** list-equiv " ++ show l1 ++ " " ++ show l2 ++
+          " expecting " ++ if l1 == l2 then "Unsat" else "Sat"
+        push
+        l1' <- listToAST l1
+        l2' <- listToAST l2
+        mkApp listEquivF [l1', l2'] >>= mkNot >>= assert
+
+        check >>= liftIO . print
+        pop 1
+        
+  push
+  
+  l4 <- listToAST [3,4,5]
+  l5 <- listToAST [3,4,8]
+
+  mkApp listEquivF [l4, l5] >>= mkNot >>= assert
+
+  solverToString >>= liftIO . putStr
+  check >>= liftIO . print
+
+  (ch, m) <- getModel
+
+  case m of Just m' -> showModel m' >>= liftIO . putStrLn
+            otherwise -> liftIO . print $ ch
+
+  pop 1
+
+  twoListsEquiv [] []
+  twoListsEquiv [1] [1]
+  twoListsEquiv [1] [1,2]
+  twoListsEquiv [1,2,3] [1,2,3]
+  twoListsEquiv [1,2,3,4,5,6] [1,2,3,5,5,6]
+  twoListsEquiv [1,2,3,4] [1,2,3]
+  twoListsEquiv [1,2,3,4,5,5,6] [1,2,3,4,5,5,6]
+  pop 1
+   
+  return ()
+
+{-
+  intList <- mkIntListDatatype
+
+  [nil, cons] <- getDatatypeSortConstructors intList
+
+  push
+  foo <- mkFreshConst "l" intList
+
+  nil' <- mkApp nil []
+
+  mkEq nil' foo
+
+  check >>= liftIO . print
+
+  solv <- solverToString -- >>= liftIO . putStr
+  liftIO $ putStrLn solv
+
+  pop 1
+
+  liftIO $ putStrLn "Hello World"
+
+-}
+
+{-
+  [nilF, consF] <- getDatatypeSortConstructors forest
+  [nilT, consT] <- getDatatypeSortConstructors tree
+
+  nilF' <- mkApp nilF []
+
+  t1 <- mkApp consT [nilF', nilF']
+  f1 <- mkApp consF [t1, nilF']
+
+  liftIO $ putStrLn "prove (NilF != ConsF(ConsT(NilT, NilT), NilF)) //Expect Unsat"
+  p <- (mkEq nilF' f1 >>= mkNot)
+  push
+  mkNot p >>= assert
+  check >>= liftIO . print
+  pop 1
+
+  liftIO $ putStrLn "prove (consF (x,u) = consF(y,v) => x = y && u = v) //Expect Unsat"
+  [x,y] <- mapM (flip mkFreshConst tree) ["x","y"]
+  [u,v] <- mapM (flip mkFreshConst forest) ["u","v"]
+  f1 <- mkApp consF [x, u]
+  f2 <- mkApp consF [y, v]
+  p1 <- mkEq f1 f2
+  p2 <- mkEq x y
+  p3 <- mkEq u v
+  p4 <- mkAnd [p2, p3]
+  p5 <- mkImplies p1 p4
+  push
+  mkNot p5 >>= assert
+  check >>= liftIO . print
+  pop 1
+-}

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -11,6 +11,7 @@ import qualified Example.Monad.QuantifierElimination
 import qualified Example.Monad.ToSMTLib
 import qualified Example.Monad.Tuple
 import qualified Example.Monad.ParserInterface
+import qualified Example.Monad.IntList
 
 import System.Environment
 
@@ -44,6 +45,9 @@ examples =
     )
   , ("parserInterface"
     , Example.Monad.ParserInterface.run
+    )
+  , ("intList"
+    , Example.Monad.IntList.run
     )
   ]
 

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -562,7 +562,8 @@ foreign import ccall unsafe "Z3_add_rec_def"
     z3_add_rec_def :: Ptr Z3_context
                    -> Ptr Z3_func_decl
                    -> CUInt
-                   -> Ptr Z3_ast_vector
+--                   -> Ptr Z3_ast_vector
+                   -> Ptr (Ptr Z3_ast)
                    -> Ptr Z3_ast
                    -> IO ()
 

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -76,6 +76,8 @@ module Z3.Monad
   , mkConst
   , mkFreshConst
   , mkFreshFuncDecl
+  , mkRecFuncDecl
+  , addRecDef
   -- ** Helpers
   , mkVar
   , mkBoolVar
@@ -841,6 +843,14 @@ mkFreshConst = liftFun2 Base.mkFreshConst
 -- Reference: <http://research.microsoft.com/en-us/um/redmond/projects/z3/group__capi.html#ga1f60c7eb41c5603e55a188a14dc929ec>
 mkFreshFuncDecl :: MonadZ3 z3 => String -> [Sort] -> Sort -> z3 FuncDecl
 mkFreshFuncDecl = liftFun3 Base.mkFreshFuncDecl
+
+-- | A recursive Z3 function
+mkRecFuncDecl :: MonadZ3 z3 => Symbol -> [Sort] -> Sort -> z3 FuncDecl
+mkRecFuncDecl = liftFun3 Base.mkRecFuncDecl
+
+-- | Define the body of a recursive Z3 function
+addRecDef :: MonadZ3 z3 => FuncDecl -> [AST] -> AST -> z3 ()
+addRecDef = liftFun3 Base.addRecDef
 
 -------------------------------------------------
 -- ** Helpers


### PR DESCRIPTION
I found I needed to define recursive functions to assert things like list equivalence and that this had been added to Z3 through functions like  Z3_mk_rec_func_decl and Z3_add_rec_def, but that the Haskell interface didn't have (complete) support for them. I added z3_add_rec_def to C.hsc and support for both mkRecFuncDecl and addRecDef to Base.hs and Monad.hs.

I added testing in the form of an example "intList" in examples/Example/Monad/IntList.hs that creates a recursive function list-equiv that is true if adding 1 to every element of the first list gives the second list.