### PR TITLE
[CI] Add script for coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,19 @@
+name: API coverage
+
+on: push
+
+jobs:
+  compute-coverage:
+    name: Compute the API coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Run coverage script
+        run: ./coverage.sh
+#      - name: Archive results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: api-coverage.log
+#          path: api-coverage.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 dist-newstyle
 .cabal-sandbox
 cabal.sandbox.config
+api-coverage

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+mkdir -p api-coverage/C
+mkdir -p api-coverage/Base
+mkdir -p api-coverage/Monad
+
+cd api-coverage
+
+# API documentation
+curl -s https://z3prover.github.io/api/html/group__capi.html | grep -e "Z3_.*" | sed -e "s/\s//g" | grep -oe "Z3_\\w*</a>(" | grep -oe "Z3_\\w*" | sort | uniq > doc-api.txt
+NUM_TOTAL_DOC="$(cat doc-api.txt | wc -l)"
+
+# C API
+cat ../src/Z3/Base/C.hsc | grep "foreign import ccall unsafe" | sed -e "s/foreign import ccall unsafe \"\(.*\)\"/\1/g" | sort | uniq > C-api.txt
+comm -23 doc-api.txt C-api.txt > C/missing.txt
+comm -13 doc-api.txt C-api.txt > C/outdated.txt
+
+function print_coverage {
+	NUM_MISSING=$1
+	NUM_TOTAL=$2
+	NUM_OUTDATED=$3
+
+	COV1=$(python3 -c "print(round((1 - $NUM_MISSING/$NUM_TOTAL_DOC)*100, 2))")
+	echo "  Covered: $((NUM_TOTAL_DOC-NUM_MISSING)) / $NUM_TOTAL_DOC ($COV1%)"
+
+	if [[ ! -z $2 ]] && [[ ! -z $3 ]]; then
+		COV2=$(python3 -c "print(round($NUM_OUTDATED/$NUM_TOTAL*100, 2))")
+		echo "  Outdated: $NUM_OUTDATED / $NUM_TOTAL ($COV2%)"
+	fi
+}
+
+echo "C API"
+print_coverage $(cat C/missing.txt | wc -l) $(cat C-api.txt | wc -l) $(cat C/outdated.txt | wc -l)
+
+echo "Base API"
+expect=$(cat doc-api.txt | sed -e "s/Z3//g" | sed -r 's/(^|_)([a-z])/\U\2/g' | sed -e 's/^./\L&/')
+
+NUM_MISSING=0
+for e in $expect; do
+	grep -q $e ../src/Z3/Base.hs || ((NUM_MISSING=NUM_MISSING+1))
+done
+
+print_coverage $NUM_MISSING
+
+echo "Monad API"
+NUM_MISSING=0
+for e in $expect; do
+	grep -q $e ../src/Z3/Monad.hs || ((NUM_MISSING=NUM_MISSING+1))
+done
+
+print_coverage $NUM_MISSING


### PR DESCRIPTION
As mentioned [in an earlier PR](https://github.com/IagoAbal/haskell-z3/pull/51#issuecomment-756016463), I think it would be neat to an automatic check for API coverage. I set up a first draft with a bash script that runs as a GitHub action and does:

1. Download the C API documentation and regex out all API functions
2. Regex out all of our calls to C API functions
3. Convert all C API function names from snake_case to camelCase and then search for them in `Base.hs` and `Monad.hs`

Obviously all those regexes are quite error prone, but here is what [it says for this PR](https://github.com/maurobringolf/haskell-z3/runs/1904298482?check_suite_focus=true#step:3:1):

```raw
C API
  Covered: 671 / 701 (95.72%)
  Outdated: 0 / 671 (0.0%)
Base API
  Covered: 306 / 701 (43.65%)
Monad API
  Covered: 273 / 701 (38.94%)
```

Running it locally will also generate files with the lists of missing/outdated API functions which are gitignored.