### PR TITLE
More lifting of a few API functions

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -541,6 +541,7 @@ module Z3.Base (
   ) where
 
 import Z3.Base.C
+import Z3.Common
 
 import Control.Applicative ( (<$>), (<*>), (<*), pure )
 import Control.Exception ( Exception, bracket, throw )
@@ -3786,11 +3787,3 @@ ptrToMaybe :: Ptr a -> Maybe (Ptr a)
 ptrToMaybe ptr | ptr == nullPtr = Nothing
                | otherwise      = Just ptr
 
--- | Wraps a monadic value in a Maybe as indicated by a boolean flag
-returnValueToMaybe :: Monad m => Bool -> m a -> m (Maybe a)
-returnValueToMaybe success m = if success then do
-                                 val <- m
-                                 return $ Just val
-                               else
-                                 return Nothing
-                                  

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -346,6 +346,9 @@ module Z3.Base (
   , getSortId
   , getSortKind
   , getBvSortSize
+  , getTupleSortMkDecl
+  , getTupleSortNumFields
+  , getTupleSortFieldDecl
   , getDatatypeSortConstructors
   , getDatatypeSortRecognizers
   , getDatatypeSortConstructorAccessors
@@ -2267,11 +2270,14 @@ getArraySortDomain = liftFun1 z3_get_array_sort_domain
 getArraySortRange :: Context -> Sort -> IO Sort
 getArraySortRange = liftFun1 z3_get_array_sort_range
 
--- TODO: Z3_get_tuple_sort_mk_decl
+getTupleSortMkDecl :: Context -> Sort -> IO FuncDecl
+getTupleSortMkDecl = liftFun1 z3_get_tuple_sort_mk_decl
 
--- TODO: Z3_get_tuple_sort_num_fields
+getTupleSortNumFields :: Context -> Sort -> IO Int
+getTupleSortNumFields = liftFun1 z3_get_tuple_sort_num_fields
 
--- TODO: Z3_get_tuple_sort_field_decl
+getTupleSortFieldDecl :: Context -> Sort -> Int -> IO FuncDecl
+getTupleSortFieldDecl = liftFun2 z3_get_tuple_sort_field_decl
 
 -- | Get list of constructors for datatype.
 getDatatypeSortConstructors :: Context

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -359,12 +359,14 @@ module Z3.Base (
   , getArity
   , getDomain
   , getRange
+  , getDeclNumParameters
   , appToAst
   , getAppDecl
   , getAppNumArgs
   , getAppArg
   , getAppArgs
   , getSort
+  , isWellSorted
   , getArraySortDomain
   , getArraySortRange
   , getBoolValue
@@ -2393,7 +2395,8 @@ getDomain = liftFun2 z3_get_domain
 getRange :: Context -> FuncDecl -> IO Sort
 getRange = liftFun1 z3_get_range
 
--- TODO: Z3_get_decl_num_parameters
+getDeclNumParameters :: Context -> FuncDecl -> IO Int
+getDeclNumParameters = liftFun1 z3_get_decl_num_parameters
 
 -- TODO: Z3_get_decl_parameter_kind
 
@@ -2443,7 +2446,8 @@ getAppArgs ctx a = do
 getSort :: Context -> AST -> IO Sort
 getSort = liftFun1 z3_get_sort
 
--- TODO: Z3_is_well_sorted
+isWellSorted :: Context -> AST -> IO Bool
+isWellSorted = liftFun1 z3_is_well_sorted
 
 -- TODO: fix doc
 -- | Return Z3_L_TRUE if a is true, Z3_L_FALSE if it is false, and Z3_L_UNDEF

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -2085,7 +2085,6 @@ type MkZ3Quantifier = Ptr Z3_context -> CUInt
                       -> Ptr Z3_ast
                       -> IO (Ptr Z3_ast)
 
--- TODO: Allow the user to specify the quantifier weight!
 marshalMkQ :: MkZ3Quantifier
           -> Context
           -> Int

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -346,6 +346,7 @@ module Z3.Base (
   , getSortId
   , getSortKind
   , getBvSortSize
+  , getFiniteDomainSortSize
   , getTupleSortMkDecl
   , getTupleSortNumFields
   , getTupleSortFieldDecl
@@ -2259,7 +2260,16 @@ getSortKind ctx sort = toSortKind <$> liftFun1 z3_get_sort_kind ctx sort
 getBvSortSize :: Context -> Sort -> IO Int
 getBvSortSize = liftFun1 z3_get_bv_sort_size
 
--- TODO: Z3_get_finite_domain_sort_size
+getFiniteDomainSortSize :: Context -> Sort -> IO (Maybe Word64)
+getFiniteDomainSortSize ctx sort = alloca $ \sizePtr ->
+  withContext ctx $ \ctxPtr ->
+    h2c sort $ \sortPtr ->
+      do success <- toBool <$> (z3_get_finite_domain_sort_size ctxPtr sortPtr sizePtr)
+         if success then do
+           size <- fromIntegral <$> peek sizePtr
+           return $ Just size
+         else
+           return Nothing
 
 -- TODO: Z3_get_array_sort_size
 

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1337,9 +1337,8 @@ foreign import ccall unsafe "Z3_get_sort_kind"
 foreign import ccall unsafe "Z3_get_bv_sort_size"
     z3_get_bv_sort_size :: Ptr Z3_context -> Ptr Z3_sort -> IO CUInt
 
--- TODO is CULong correct?
 foreign import ccall unsafe "Z3_get_finite_domain_sort_size"
-    z3_get_finite_domain_sort_size :: Ptr Z3_context -> Ptr Z3_sort -> Ptr CULong -> IO Z3_bool
+    z3_get_finite_domain_sort_size :: Ptr Z3_context -> Ptr Z3_sort -> Ptr CULLong -> IO Z3_bool
 
 -- | Reference: <https://z3prover.github.io/api/html/group__capi.html#ga6ffa46d55e4632d761db4dfae7441c09>
 foreign import ccall unsafe "Z3_get_array_sort_domain"

--- a/src/Z3/Common.hs
+++ b/src/Z3/Common.hs
@@ -1,0 +1,22 @@
+-- |
+-- Module    : Z3.Common
+-- Copyright : (c) Iago Abal, 2013-2015
+--             (c) David Castro, 2013
+-- License   : BSD3
+-- Maintainer: Iago Abal <mail@iagoabal.eu>,
+--             David Castro <david.castro.dcp@gmail.com>
+--
+-- Common utils for other modules.
+--
+--
+
+module Z3.Common where
+
+-- | Wraps a monadic value in a Maybe as indicated by a boolean flag
+returnValueToMaybe :: Monad m => Bool -> m a -> m (Maybe a)
+returnValueToMaybe success m = if success then do
+                                 val <- m
+                                 return $ Just val
+                               else
+                                 return Nothing
+

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -267,6 +267,9 @@ module Z3.Monad
   , isEqSort
   , getSortKind
   , getBvSortSize
+  , getTupleSortMkDecl
+  , getTupleSortNumFields
+  , getTupleSortFieldDecl
   , getDatatypeSortConstructors
   , getDatatypeSortRecognizers
   , getDatatypeSortConstructorAccessors
@@ -1854,6 +1857,16 @@ getSortKind = liftFun1 Base.getSortKind
 -- Reference: <http://research.microsoft.com/en-us/um/redmond/projects/z3/group__capi.html#ga8fc3550edace7bc046e16d1f96ddb419>
 getBvSortSize :: MonadZ3 z3 => Sort -> z3 Int
 getBvSortSize = liftFun1 Base.getBvSortSize
+
+
+getTupleSortMkDecl :: MonadZ3 z3 => Sort -> z3 FuncDecl
+getTupleSortMkDecl = liftFun1 Base.getTupleSortMkDecl
+
+getTupleSortNumFields :: MonadZ3 z3 => Sort -> z3 Int
+getTupleSortNumFields = liftFun1 Base.getTupleSortNumFields
+
+getTupleSortFieldDecl :: MonadZ3 z3 => Sort -> Int -> z3 FuncDecl
+getTupleSortFieldDecl = liftFun2 Base.getTupleSortFieldDecl
 
 -- | Get list of constructors for datatype.
 getDatatypeSortConstructors :: MonadZ3 z3

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -398,7 +398,11 @@ spec = around withContext $ do
         f3 <- Z3.mkStringSymbol ctx "f3"
         int <- Z3.mkIntSort ctx
         bool <- Z3.mkBoolSort ctx
-        (_, cons, [f1proj, f2proj, f3proj]) <- Z3.mkTupleSort ctx name [(f1, int), (f2, bool), (f3, bool)]
+        (myTuple, cons, [f1proj, f2proj, f3proj]) <- Z3.mkTupleSort ctx name [(f1, int), (f2, bool), (f3, bool)]
+
+        correctDecl <- (== cons) <$> Z3.getTupleSortMkDecl ctx myTuple
+        correctNumFields <- (== 3) <$> Z3.getTupleSortNumFields ctx myTuple
+        correctGetFieldDecl <- (== f2proj) <$> Z3.getTupleSortFieldDecl ctx myTuple 1
 
         one <- Z3.mkIntNum ctx i
         b1 <- Z3.mkBool ctx b1v
@@ -412,8 +416,9 @@ spec = around withContext $ do
         x1 <- Z3.evalInt ctx model =<< Z3.mkApp ctx f1proj [tuple]
         x2 <- Z3.evalBool ctx model =<< Z3.mkApp ctx f2proj [tuple]
         x3 <- Z3.evalBool ctx model =<< Z3.mkApp ctx f3proj [tuple]
-        return (x1,x2,x3)
-      ) `shouldReturn` (Just i, Just b1v, Just b2v)
+        return (correctDecl, correctNumFields, correctGetFieldDecl, x1,x2,x3)
+
+      ) `shouldReturn` (True, True, True, Just i, Just b1v, Just b2v)
 
     specify "mkTupleType, mkTuple, mkIndexTuple, mkProjTuple" $ \ctx -> property $ \(i::Integer) (b1v::Bool) (b2v::Bool) ->
       (do

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -6,9 +6,11 @@ module Z3.Base.Spec
 
 import Data.Maybe (fromJust)
 import Test.Hspec
-import Test.QuickCheck ( property, choose )
+import Test.QuickCheck ( property, choose, (==>) )
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Monadic
+
+import Data.Word(Word64)
 
 import qualified Z3.Base as Z3
 
@@ -470,3 +472,15 @@ spec = around withContext $ do
 
         Z3.evalInt ctx model =<< mkApp' ctx f1proj =<< mkApp' ctx f2proj =<< mkApp' ctx t2cons =<< Z3.mkApp ctx t1cons [x]
       ) `shouldReturn` Just i
+
+
+  context "Finite Domain Sorts" $ do
+
+    specify "mkFiniteDomainSort, getFiniteDomainSortSize" $ \ctx -> property $ \(i::Word64) ->
+      -- Z3 does not allow empty sorts
+      (i /= 0 ==>
+        (do
+          name <- Z3.mkStringSymbol ctx "name"
+          s <- Z3.mkFiniteDomainSort ctx name i
+          Z3.getFiniteDomainSortSize ctx s
+        ) `shouldReturn` Just i)

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -484,3 +484,16 @@ spec = around withContext $ do
           s <- Z3.mkFiniteDomainSort ctx name i
           Z3.getFiniteDomainSortSize ctx s
         ) `shouldReturn` Just i)
+
+  context "Function Declarations" $ do
+
+    specify "getArity" $ \ctx ->
+      (do
+        fun <- Z3.mkStringSymbol ctx "fun"
+        int <- Z3.mkIntSort ctx
+        bool <- Z3.mkBoolSort ctx
+        fdecl <- Z3.mkFuncDecl ctx fun [int, int, int] bool
+        arity <- Z3.getArity ctx fdecl
+        return arity
+      ) `shouldReturn` 3
+

--- a/z3.cabal
+++ b/z3.cabal
@@ -53,6 +53,9 @@ Library
 
         Z3.Monad
 
+    Other-Modules:
+	    Z3.Common
+
     -- TODO: Add flag to compile with -Werror, Hackage doesn't like it.
     ghc-options: -Wall
 
@@ -133,6 +136,7 @@ Test-suite spec
     Other-modules:      Z3.Base.Spec
                         Z3.Monad.Spec
                         Z3.Regression
+                        Example.Monad.IntList
 
     Build-depends:      base >= 4.5,
                         z3,


### PR DESCRIPTION
Two interesting things:

1. I introduced `returnValueToMaybe :: Monad m => Bool -> m a -> m (Maybe a)`, but then found out that this exists in `Control.Monad.Extra` as `whenMaybe`. So I replaced my own with this dependency, but if you favor dropping the dependency and keeping our own implementation I can undo the last commit.
2. I couldn't think of a way to test `isWellSorted` since ASTs constructed through the API are always well sorted as far as I can tell. But now that I am writing this I realize that it might be possible by directly manipulating an AST through `poke`.