### PR TITLE
Lift a few more functions from the tactics API and examples from the Z3 tutorial

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -446,9 +446,11 @@ module Z3.Base (
   , orElseTactic
   , skipTactic
   , tryForTactic
+  , repeatTactic
   , mkQuantifierEliminationTactic
   , mkAndInverterGraphTactic
   , applyTactic
+  , applyResultToString
   , getApplyResultNumSubgoals
   , getApplyResultSubgoal
   , getApplyResultSubgoals
@@ -457,6 +459,7 @@ module Z3.Base (
   , getGoalSize
   , getGoalFormula
   , getGoalFormulas
+  , goalToString
 
   -- * String Conversion
   , ASTPrintMode(..)
@@ -1892,10 +1895,9 @@ mkSeqUnit :: Context -> AST -> IO AST
 mkSeqUnit = liftFun1 z3_mk_seq_unit
 
 -- | Concatenate sequences.
-mkSeqConcat :: (Integral int) => Context -> int -> [AST] -> IO AST
-mkSeqConcat c i as
-  | i <  0            = error "Z3.Base.mkSeqConcat: negative size"
-  | i >= 0 && null as = error "Z3.Base.mkSeqConcet: empty list of expressions"
+mkSeqConcat :: Context -> [AST] -> IO AST
+mkSeqConcat c as
+  | null as = error "Z3.Base.mkSeqConcet: empty list of expressions"
   | otherwise         = marshal z3_mk_seq_concat c $ marshalArrayLen as
 
 -- | Check if prefix is a prefix of s.
@@ -2977,6 +2979,9 @@ skipTactic = liftFun0 z3_tactic_skip
 tryForTactic :: Context -> Tactic -> Int -> IO Tactic
 tryForTactic = liftFun2 z3_tactic_try_for
 
+repeatTactic :: Context -> Tactic -> Int -> IO Tactic
+repeatTactic = liftFun2 z3_tactic_repeat
+
 mkQuantifierEliminationTactic :: Context -> IO Tactic
 mkQuantifierEliminationTactic ctx = mkTactic ctx "qe"
 
@@ -2985,6 +2990,9 @@ mkAndInverterGraphTactic ctx = mkTactic ctx "aig"
 
 applyTactic :: Context -> Tactic -> Goal -> IO ApplyResult
 applyTactic = liftFun2 z3_tactic_apply
+
+applyResultToString :: Context -> ApplyResult -> IO String
+applyResultToString = liftFun1 z3_apply_result_to_string
 
 getApplyResultNumSubgoals :: Context -> ApplyResult -> IO Int
 getApplyResultNumSubgoals = liftFun1 z3_apply_result_get_num_subgoals
@@ -3013,6 +3021,9 @@ getGoalFormulas :: Context -> Goal -> IO [AST]
 getGoalFormulas ctx g = do
   n <- getGoalSize ctx g
   T.forM [0..n-1] (getGoalFormula ctx g)
+
+goalToString :: Context -> Goal -> IO String
+goalToString = liftFun1 z3_goal_to_string
 
 ---------------------------------------------------------------------
 -- Parser interface

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -364,9 +364,11 @@ module Z3.Monad
   , orElseTactic
   , skipTactic
   , tryForTactic
+  , repeatTactic
   , mkQuantifierEliminationTactic
   , mkAndInverterGraphTactic
   , applyTactic
+  , applyResultToString
   , getApplyResultNumSubgoals
   , getApplyResultSubgoal
   , getApplyResultSubgoals
@@ -375,6 +377,7 @@ module Z3.Monad
   , getGoalSize
   , getGoalFormula
   , getGoalFormulas
+  , goalToString
 
   -- * String Conversion
   , ASTPrintMode(..)
@@ -1646,8 +1649,8 @@ mkSeqUnit :: MonadZ3 z3 => AST -> z3 AST
 mkSeqUnit = liftFun1 Base.mkSeqUnit
 
 -- | Concatenate sequences.
-mkSeqConcat :: (Integral int, MonadZ3 z3) => int -> [AST] -> z3 AST
-mkSeqConcat = liftFun2 Base.mkSeqConcat
+mkSeqConcat :: MonadZ3 z3 => [AST] -> z3 AST
+mkSeqConcat = liftFun1 Base.mkSeqConcat
 
 -- | Check if prefix is a prefix of s.
 mkSeqPrefix :: MonadZ3 z3
@@ -2276,6 +2279,9 @@ skipTactic = liftScalar Base.skipTactic
 tryForTactic :: MonadZ3 z3 => Tactic -> Int -> z3 Tactic
 tryForTactic = liftFun2 Base.tryForTactic
 
+repeatTactic :: MonadZ3 z3 => Tactic -> Int -> z3 Tactic
+repeatTactic = liftFun2 Base.repeatTactic
+
 mkQuantifierEliminationTactic :: MonadZ3 z3 => z3 Tactic
 mkQuantifierEliminationTactic = liftScalar Base.mkQuantifierEliminationTactic
 
@@ -2284,6 +2290,9 @@ mkAndInverterGraphTactic = liftScalar Base.mkAndInverterGraphTactic
 
 applyTactic :: MonadZ3 z3 => Tactic -> Goal -> z3 ApplyResult
 applyTactic = liftFun2 Base.applyTactic
+
+applyResultToString :: MonadZ3 z3 => ApplyResult -> z3 String
+applyResultToString = liftFun1 Base.applyResultToString
 
 getApplyResultNumSubgoals :: MonadZ3 z3 => ApplyResult -> z3 Int
 getApplyResultNumSubgoals = liftFun1 Base.getApplyResultNumSubgoals
@@ -2308,6 +2317,9 @@ getGoalFormula = liftFun2 Base.getGoalFormula
 
 getGoalFormulas :: MonadZ3 z3 => Goal -> z3 [AST]
 getGoalFormulas = liftFun1 Base.getGoalFormulas
+
+goalToString :: MonadZ3 z3 => Goal -> z3 String
+goalToString = liftFun1 Base.goalToString
 
 ---------------------------------------------------------------------
 -- String Conversion

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 import qualified Z3.Base.Spec
 import qualified Z3.Monad.Spec
 import qualified Z3.Regression
+import qualified Z3.Tutorial
 
 main :: IO ()
 main = hspec spec
@@ -13,3 +14,4 @@ spec = do
   describe "Z3.Base" Z3.Base.Spec.spec
   describe "Z3.Monad" Z3.Monad.Spec.spec
   describe "Z3.Regression" Z3.Regression.spec
+  describe "Z3.Tutorial" Z3.Tutorial.spec

--- a/test/Z3/Tutorial.hs
+++ b/test/Z3/Tutorial.hs
@@ -1,0 +1,129 @@
+module Z3.Tutorial
+  ( spec )
+  where
+
+import Test.Hspec
+
+import Control.Monad(forM_)
+import Control.Monad.IO.Class
+
+import qualified Z3.Base as Z3
+import qualified Z3.Monad
+
+spec :: Spec
+spec = do
+  describe "Section: Basic Commands" $ do
+    it "Basic function definition" $
+      (fst <$> Z3.Monad.evalZ3 basicFunctionDefinition) `shouldReturn` Z3.Monad.Sat
+  describe "Section: Strategies" $ do
+    describe "Section: Introduction" $ do
+      it "Apply simplify and solve-eq tactics" $
+        Z3.Monad.evalZ3 simplifySolveEqs `shouldReturn` "(goals\n(goal\n  (not (<= y (- 2.0)))\n  (not (<= y 0.0)))\n)"
+      it "Apply split-clause tactic" $
+        Z3.Monad.evalZ3 applySplitClause `shouldReturn` "(goals\n(goal\n  (< x 0.0)\n  (= x (+ y 1.0))\n  (< y 0.0))\n(goal\n  (> x 0.0)\n  (= x (+ y 1.0))\n  (< y 0.0))\n)"
+  describe "Section: Sequences" $ do
+    describe "Section: Strings" $ do
+      it "stringConcatentation" $
+        Z3.Monad.evalZ3 stringConcatentation `shouldReturn` "b -> \"ab\"\na -> \"cab\"\n"
+
+{-
+  (declare-const a String)
+  (declare-const b String)
+  (assert (= (str.++ b a) (str.++ "abc" b)))
+  (check-sat)
+  (get-model)
+-}
+stringConcatentation :: Z3.Monad.Z3 String
+stringConcatentation = do
+  s <- Z3.Monad.mkStringSort
+  asym <- Z3.Monad.mkStringSymbol "a"
+  bsym <- Z3.Monad.mkStringSymbol "b"
+  a <- Z3.Monad.mkConst asym s
+  b <- Z3.Monad.mkConst bsym s
+  abcLit <- Z3.Monad.mkString "abc"
+  lhs <- Z3.Monad.mkSeqConcat [b,a]
+  rhs <- Z3.Monad.mkSeqConcat [abcLit, b]
+  Z3.Monad.assert =<< Z3.Monad.mkEq lhs rhs
+  (Z3.Sat, Just m) <- Z3.Monad.solverCheckAndGetModel
+  Z3.Monad.modelToString m
+
+{-
+  (declare-const a Int)
+  (declare-fun f (Int Bool) Int)
+  (assert (> a 10))
+  (assert (< (f a true) 100))
+  (check-sat)
+-}
+basicFunctionDefinition :: Z3.Monad.Z3 (Z3.Monad.Result, Maybe Z3.Monad.Model)
+basicFunctionDefinition = do
+  b <- Z3.Monad.mkBoolSort
+  i <- Z3.Monad.mkIntSort
+  asym <- Z3.Monad.mkStringSymbol "a"
+  a <- Z3.Monad.mkConst asym i
+  fsym <- Z3.Monad.mkStringSymbol "f"
+  fDecl <- Z3.Monad.mkFuncDecl fsym [i, b] i
+  Z3.Monad.assert =<< Z3.Monad.mkGt a =<< Z3.Monad.mkInt 10 i
+  Z3.Monad.solverCheckAndGetModel
+
+{-
+  (declare-const x Real)
+  (declare-const y Real)
+
+  (assert (> x 0.0))
+  (assert (> y 0.0))
+  (assert (= x (+ y 2.0)))
+
+  (apply (then simplify solve-eqs))
+-}
+simplifySolveEqs :: Z3.Monad.Z3 String
+simplifySolveEqs = do
+  real <- Z3.Monad.mkRealSort
+  xsym <- Z3.Monad.mkStringSymbol "x"
+  ysym <- Z3.Monad.mkStringSymbol "y"
+  x <- Z3.Monad.mkConst xsym real
+  y <- Z3.Monad.mkConst ysym real
+  r0 <- Z3.Monad.mkReal 0 1
+  r2 <- Z3.Monad.mkReal 2 1
+
+  goal <- Z3.Monad.mkGoal False False False
+
+  Z3.Monad.goalAssert goal =<< Z3.Monad.mkGt x r0
+  Z3.Monad.goalAssert goal =<< Z3.Monad.mkGt y r0
+  rhs <- Z3.Monad.mkAdd [y, r2]
+  Z3.Monad.goalAssert goal =<< Z3.Monad.mkEq x rhs
+
+  simplify <- Z3.Monad.mkTactic "simplify"
+  solveEqs <- Z3.Monad.mkTactic "solve-eqs"
+  tactic <- Z3.Monad.andThenTactic simplify solveEqs
+  Z3.Monad.applyResultToString =<< Z3.Monad.applyTactic tactic goal
+
+
+{-
+  (declare-const x Real)
+  (declare-const y Real)
+
+  (assert (or (< x 0.0) (> x 0.0)))
+  (assert (= x (+ y 1.0)))
+  (assert (< y 0.0))
+
+  (apply split-clause)
+-}
+applySplitClause :: Z3.Monad.Z3 String
+applySplitClause = do
+  real <- Z3.Monad.mkRealSort
+  xsym <- Z3.Monad.mkStringSymbol "x"
+  ysym <- Z3.Monad.mkStringSymbol "y"
+  x <- Z3.Monad.mkConst xsym real
+  y <- Z3.Monad.mkConst ysym real
+  r0 <- Z3.Monad.mkReal 0 1
+  r1 <- Z3.Monad.mkReal 1 1
+
+  goal <- Z3.Monad.mkGoal False False False
+  xLt0 <- Z3.Monad.mkLt x r0
+  xGt0 <- Z3.Monad.mkGt x r0
+  Z3.Monad.goalAssert goal =<< Z3.Monad.mkOr [xLt0, xGt0]
+  Z3.Monad.goalAssert goal =<< Z3.Monad.mkEq x =<< Z3.Monad.mkAdd [y, r1]
+  Z3.Monad.goalAssert goal =<< Z3.Monad.mkLt y r0
+
+  tactic <- Z3.Monad.mkTactic "split-clause"
+  Z3.Monad.applyResultToString =<< Z3.Monad.applyTactic tactic goal


### PR DESCRIPTION
I looked a bit into the [Z3 tutorial](https://rise4fun.com/Z3/tutorial/) and thought the examples from there might make some good tests for us. So I added a few of them. I tried quite a few more, but sometimes failed because examples use features that are either not accessible through the API or result in slightly different behavior.

During this process I made some minor improvements in both `Z3.Base` and `Z3.Monad`:

1. Added `repeatTactic`, `applyResultToString`, `goalToString`

2. Removed an unused integer parameter from the API of `mkSeqConcat`. I presume this was used as the length of arguments in an earlier version, but `marshalArrayLen` takes care of that.