### PR TITLE
Collection of small fixes

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -11,7 +11,7 @@ jobs:
           ghc-version: '8.10'
           cabal-version: '3.2'
       - run: |
-          Z3_URL=https://github.com$(curl -sL https://github.com/z3prover/z3/releases/latest | grep -oe "href.*x64-ubuntu.*\.zip\"" | sed -e "s/href=\"\(.*\)\"/\1/g")
+          Z3_URL=https://github.com$(curl -sL https://github.com/z3prover/z3/releases/latest | grep -oe "href.*x64-glibc.*\.zip\"" | sed -e "s/href=\"\(.*\)\"/\1/g")
           echo "z3_url=$Z3_URL" >> $GITHUB_ENV
           echo "z3_dir=$(basename $Z3_URL .zip)" >> $GITHUB_ENV
       - run: |

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -531,6 +531,7 @@ module Z3.Base (
   , solverGetNumScopes
   , solverAssertCnstr
   , solverAssertAndTrack
+  , solverFromFile
   , solverGetAssertions
   , solverCheck
   , solverCheckAssumptions
@@ -3057,7 +3058,7 @@ parseSMTLib2File :: Context
                  -> [FuncDecl] -- ^ declarations
                  -> IO [AST]
 parseSMTLib2File ctx file sortNames sorts declNames decls =
-  marshal z3_parse_smtlib2_string ctx $ \f ->
+  marshal z3_parse_smtlib2_file ctx $ \f ->
     withCString file $ \fileName ->
     marshalArrayLen sorts $ \sortNum sortArr ->
     marshalArray sortNames $ \sortNameArr ->
@@ -3453,6 +3454,9 @@ solverAssertCnstr = liftFun2 z3_solver_assert
 
 solverAssertAndTrack :: Context -> Solver -> AST -> AST -> IO ()
 solverAssertAndTrack = liftFun3 z3_solver_assert_and_track
+
+solverFromFile :: Context -> Solver -> String -> IO ()
+solverFromFile = liftFun2 z3_solver_from_file
 
 solverGetAssertions :: Context -> Solver -> IO [AST]
 solverGetAssertions = liftFun1 z3_solver_get_assertions

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1944,7 +1944,7 @@ foreign import ccall unsafe "Z3_parse_smtlib2_file"
                         -> CUInt
                         -> Ptr (Ptr Z3_symbol)
                         -> Ptr (Ptr Z3_func_decl)
-                        -> IO (Ptr Z3_ast)
+                        -> IO (Ptr Z3_ast_vector)
 
 foreign import ccall unsafe "Z3_eval_smtlib2_string"
   z3_eval_smtlib2_string :: Ptr Z3_context

--- a/test/Z3/Tutorial.hs
+++ b/test/Z3/Tutorial.hs
@@ -24,7 +24,7 @@ spec = do
   describe "Section: Sequences" $ do
     describe "Section: Strings" $ do
       it "stringConcatentation" $
-        Z3.Monad.evalZ3 stringConcatentation `shouldReturn` "b -> \"ab\"\na -> \"cab\"\n"
+        Z3.Monad.evalZ3 stringConcatentation `shouldReturn` "b -> \"\"\na -> \"abc\"\n"
 
 {-
   (declare-const a String)


### PR DESCRIPTION
1. Fix broken `parseSMTLib2File`
2. Add `solverFromFile`
3. Z3-4.8.12 compatibility: The new version returns a different model which I tested for in the testsuite. And the naming scheme for downloading latest release also changed.