### PR TITLE
Add binding to `Z3_eval_smtlib2_string`

### DIFF
--- a/examples/Example/Monad/ParserEvalInterface.hs
+++ b/examples/Example/Monad/ParserEvalInterface.hs
@@ -1,0 +1,33 @@
+-- | Parse SMTLIB string and evaluate it, line by line
+module Example.Monad.ParserEvalInterface
+  ( run )
+  where
+
+import Z3.Monad
+
+run :: IO ()
+run = do
+  outputs <- evalZ3 script
+  traverse putStr outputs >> return ()
+
+-- Toy example SMTLIB string
+smtLines :: [ String ]
+smtLines = [ "(set-option :print-success true)"
+           , "(set-option :produce-models true)"
+           , "(declare-const x Int)"
+           , "(assert (< x 5))"
+           , "(declare-const y Int)"
+           , "(assert (= x y))"
+           , "(push 1)"
+           , "(assert (> y 5))"
+           , "(check-sat)"
+           , "(pop 1)"
+           , "(push 1)"
+           , "(assert (> y 3))"
+           , "(check-sat)"
+           , "(get-value (x y))"
+           , "(pop 1)"
+           , "(exit)" ]
+
+script :: Z3 [String]
+script = traverse evalSMTLib2String smtLines

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -11,6 +11,7 @@ import qualified Example.Monad.QuantifierElimination
 import qualified Example.Monad.ToSMTLib
 import qualified Example.Monad.Tuple
 import qualified Example.Monad.ParserInterface
+import qualified Example.Monad.ParserEvalInterface
 import qualified Example.Monad.IntList
 
 import System.Environment
@@ -46,6 +47,8 @@ examples =
   , ("parserInterface"
     , Example.Monad.ParserInterface.run
     )
+  , ("parserEvalInterface"
+    , Example.Monad.ParserEvalInterface.run)
   , ("intList"
     , Example.Monad.IntList.run
     )

--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -476,6 +476,7 @@ module Z3.Base (
   -- * Parser interface
   , parseSMTLib2String
   , parseSMTLib2File
+  , evalSMTLib2String
 
   -- * Error Handling
   , Z3Error(..)
@@ -3160,6 +3161,13 @@ parseSMTLib2File ctx file sortNames sorts declNames decls =
     marshalArray declNames $ \declNameArr ->
       f fileName sortNum sortNameArr sortArr declNum declNameArr declArr
 
+evalSMTLib2String :: Context
+                  -> String    -- ^ string to parse
+                  -> IO String
+evalSMTLib2String ctx cmd =
+  marshal z3_eval_smtlib2_string ctx $ \f ->
+    withCString cmd $ \command ->
+      f command
 
 ---------------------------------------------------------------------
 -- Error handling
@@ -3340,7 +3348,7 @@ mkFpaRtz :: Context -> IO AST
 mkFpaRtz = liftFun0 z3_mk_fpa_rtz
 
 -- | Create a FloatingPoint sort.
-mkFpaSort :: Integral int 
+mkFpaSort :: Integral int
           => Context -- ^ Context
           -> int -- ^ Number of exponent bits
           -> int -- ^ Number of significand bits
@@ -3428,7 +3436,7 @@ mkFpaNumeralInt = liftFun2 z3_mk_fpa_numeral_int
 
 -- | Create a numeral of FLoatingPoint sort from a sign bit and
 -- two integers.
-mkFpaNumeralIntUInt :: Integral int 
+mkFpaNumeralIntUInt :: Integral int
                     => Context -- ^ Context
                     -> Bool    -- ^ Sign bit (true == negative)
                     -> int     -- ^ Significand
@@ -3439,7 +3447,7 @@ mkFpaNumeralIntUInt = liftFun4 z3_mk_fpa_numeral_int_uint
 
 -- | Create a numeral of FloatingPoint sort from a sign bit and
 -- two 64-bit integers.
-mkFpaNumeralInt64UInt64 :: Integral int 
+mkFpaNumeralInt64UInt64 :: Integral int
                         => Context -- ^ Context
                         -> Bool    -- ^ Sign bit (true == negative)
                         -> int     -- ^ Significand
@@ -4175,7 +4183,7 @@ instance Marshal String CString where
   h2c   = withCString
 
 instance Marshal Context (Ptr Z3_context) where
-  c2h _ ctx = withConfig $ mkContextWith (const (return ctx)) 
+  c2h _ ctx = withConfig $ mkContextWith (const (return ctx))
   h2c ctx = withForeignPtr (unContext ctx)
 
 instance Marshal App (Ptr Z3_app) where
@@ -4331,4 +4339,3 @@ unBool False = z3_false
 ptrToMaybe :: Ptr a -> Maybe (Ptr a)
 ptrToMaybe ptr | ptr == nullPtr = Nothing
                | otherwise      = Just ptr
-

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1934,7 +1934,7 @@ foreign import ccall unsafe "Z3_parse_smtlib2_string"
                           -> Ptr (Ptr Z3_func_decl)
                           -> IO (Ptr Z3_ast_vector)
 
--- | Referece <http://z3prover.github.io/api/html/group__capi.html#ga6168be4babb03fbbccff1fa7df451300>
+-- | Reference <http://z3prover.github.io/api/html/group__capi.html#ga6168be4babb03fbbccff1fa7df451300>
 foreign import ccall unsafe "Z3_parse_smtlib2_file"
   z3_parse_smtlib2_file :: Ptr Z3_context
                         -> Z3_string

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -394,6 +394,7 @@ module Z3.Monad
   -- * Parser interface
   , parseSMTLib2String
   , parseSMTLib2File
+  , evalSMTLib2String
 
   -- * Error Handling
   , Base.Z3Error(..)
@@ -2502,6 +2503,11 @@ parseSMTLib2File :: MonadZ3 z3 =>
                  -> [FuncDecl] -- ^ declarations
                  -> z3 [AST]
 parseSMTLib2File = liftFun5 Base.parseSMTLib2File
+
+evalSMTLib2String :: MonadZ3 z3 =>
+                     String     -- ^ string to parse
+                  -> z3 String
+evalSMTLib2String = liftFun1 Base.evalSMTLib2String
 
 ---------------------------------------------------------------------
 -- Miscellaneous

--- a/z3.cabal
+++ b/z3.cabal
@@ -116,6 +116,7 @@ Executable examples
                        Example.Monad.FuncModel
                        Example.Monad.MutuallyRecursive
                        Example.Monad.ParserInterface
+                       Example.Monad.ParserEvalInterface
                        Example.Monad.Quantifiers
                        Example.Monad.QuantifierElimination
                        Example.Monad.ToSMTLib


### PR DESCRIPTION
The `Z3_eval_smtlib2_string` function from the C API wasn't available in the Haskell API. This pull request adds it as well as an example demonstrating its use.

It also fixes a typo in the documentation for `z3_parse_smtlib2_file` and removes some extra whitespace in `Base.hs` (this should ideally be in a separate pull request but I noticed it too late, sorry).