### PR TITLE
Add bindigs for getting algebraic numbers

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -374,10 +374,17 @@ module Z3.Base (
   , getBoolValue
   , getAstKind
   , isApp
+  , isNumeralAst
+  , isAlgebraicNumber
   , toApp
   , getNumeralString
+  , getNumeralBinaryString
+  , getNumeralDecimalString
+  , getNumeralDouble
   , getNumerator
   , getDenominator
+  , getAlgebraicNumberLower
+  , getAlgebraicNumberUpper
   , simplify
   , simplifyEx
   , getIndexValue
@@ -2585,9 +2592,12 @@ getAstKind ctx ast = toAstKind <$> liftFun1 z3_get_ast_kind ctx ast
 isApp :: Context -> AST -> IO Bool
 isApp = liftFun1 z3_is_app
 
--- TODO: Z3_is_numeral_ast
+isNumeralAst :: Context -> AST -> IO Bool
+isNumeralAst = liftFun1 z3_is_numeral_ast
 
--- TODO: Z3_is_algebraic_number
+-- | Return True if an ast represents an algebraic number, False otherwise.
+isAlgebraicNumber :: Context -> AST -> IO Bool
+isAlgebraicNumber = liftFun1 z3_is_algebraic_number
 
 -- | Convert an ast into an APP_AST. This is just type casting.
 toApp :: Context -> AST -> IO App
@@ -2596,10 +2606,28 @@ toApp = liftFun1 z3_to_app
 -- TODO: Z3_to_func_decl
 
 -- | Return numeral value, as a string of a numeric constant term.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gae0ffdaa5b0d9c2deb3bbb8d78ac9f4c9>
 getNumeralString :: Context -> AST -> IO String
 getNumeralString = liftFun1 z3_get_numeral_string
 
--- TODO: Z3_get_numeral_decimal_string
+-- | Return numeral value, as a binary string of a numeric constant term.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gae959d9267eb1567887e5ed665a947d5a>
+getNumeralBinaryString :: Context -> AST -> IO String
+getNumeralBinaryString = liftFun1 z3_get_numeral_binary_string
+
+-- | Return numeral as a string in decimal notation. The result has at most precision decimal places.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gaf8e1ec34d62bb2c45a8aa7394593d7fb>
+getNumeralDecimalString :: Context -> AST -> Int -> IO String
+getNumeralDecimalString = liftFun2 z3_get_numeral_decimal_string
+
+-- | Return numeral as a double.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gaf48e7b61664c0273a4ec77649f0a00cd>
+getNumeralDouble :: Context -> AST -> IO Double
+getNumeralDouble = liftFun1 z3_get_numeral_double
 
 -- | Return the numerator (as a numeral AST) of a numeral AST of sort Real.
 --
@@ -2627,9 +2655,21 @@ getDenominator = liftFun1 z3_get_denominator
 
 -- TODO: Z3_get_numeral_rational_int64
 
--- TODO: Z3_get_algebraic_number_lower
+-- | Return a lower bound for the given real algebraic number.
+--   The interval isolating the number is smaller than 1/10^precision.
+--   The result is a numeral AST of sort Real.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga40775ed34e6fcf184b7a0a30deaf2a03>
+getAlgebraicNumberLower :: Context -> AST -> Int -> IO AST
+getAlgebraicNumberLower = liftFun2 z3_get_algebraic_number_lower
 
--- TODO: Z3_get_algebraic_number_upper
+-- | Return a upper bound for the given real algebraic number.
+--   The interval isolating the number is smaller than 1/10^precision.
+--   The result is a numeral AST of sort Real.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga84019f84e6a2e69d3bdfc80441ca0f7d>
+getAlgebraicNumberUpper :: Context -> AST -> Int -> IO AST
+getAlgebraicNumberUpper = liftFun2 z3_get_algebraic_number_upper
 
 -- TODO: Z3_pattern_to_ast
 

--- a/src/Z3/Base/C.hsc
+++ b/src/Z3/Base/C.hsc
@@ -1498,11 +1498,13 @@ foreign import ccall unsafe "Z3_get_ast_kind"
 foreign import ccall unsafe "Z3_is_app"
     z3_is_app :: Ptr Z3_context -> Ptr Z3_ast -> IO Bool
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#ga5488eba2e207d6e18cfe5b5a41b1c235>
 foreign import ccall unsafe "Z3_is_numeral_ast"
-    z3_is_numeral_ast :: Ptr Z3_context -> Ptr Z3_ast -> IO Bool
+  z3_is_numeral_ast :: Ptr Z3_context -> Ptr Z3_ast -> IO Bool
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#gaff8b2c4087e628c51c713315cc0ed861>
 foreign import ccall unsafe "Z3_is_algebraic_number"
-    z3_is_algebraic_number :: Ptr Z3_context -> Ptr Z3_ast -> IO Bool
+  z3_is_algebraic_number :: Ptr Z3_context -> Ptr Z3_ast -> IO Bool
 
 -- | Reference: <http://z3prover.github.io/api/html/group__capi.html#gaf9345fd0822d7e9928dd4ab14a09765b>
 foreign import ccall unsafe "Z3_to_app"
@@ -1515,12 +1517,15 @@ foreign import ccall unsafe "Z3_to_func_decl"
 foreign import ccall unsafe "Z3_get_numeral_string"
     z3_get_numeral_string :: Ptr Z3_context -> Ptr Z3_ast -> IO Z3_string
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#gae959d9267eb1567887e5ed665a947d5a>
 foreign import ccall unsafe "Z3_get_numeral_binary_string"
   z3_get_numeral_binary_string :: Ptr Z3_context -> Ptr Z3_ast -> IO Z3_string
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#gaf8e1ec34d62bb2c45a8aa7394593d7fb>
 foreign import ccall unsafe "Z3_get_numeral_decimal_string"
-  z3_get_numeral_decimal_string :: Ptr Z3_context -> Ptr Z3_ast -> IO Z3_string
+  z3_get_numeral_decimal_string :: Ptr Z3_context -> Ptr Z3_ast -> CUInt -> IO Z3_string
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#gaf48e7b61664c0273a4ec77649f0a00cd>
 foreign import ccall unsafe "Z3_get_numeral_double"
   z3_get_numeral_double :: Ptr Z3_context -> Ptr Z3_ast -> IO CDouble
 
@@ -1550,9 +1555,11 @@ foreign import ccall unsafe "Z3_get_numeral_int64"
 foreign import ccall unsafe "Z3_get_numeral_rational_int64"
   z3_get_numeral_rational_int64 :: Ptr Z3_context -> Ptr Z3_ast -> Ptr CLong -> Ptr CLong -> IO Bool
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#ga40775ed34e6fcf184b7a0a30deaf2a03>
 foreign import ccall unsafe "Z3_get_algebraic_number_lower"
   z3_get_algebraic_number_lower :: Ptr Z3_context -> Ptr Z3_ast -> CUInt -> IO (Ptr Z3_ast)
 
+-- | Reference: <https://z3prover.github.io/api/html/group__capi.html#ga84019f84e6a2e69d3bdfc80441ca0f7d>
 foreign import ccall unsafe "Z3_get_algebraic_number_upper"
   z3_get_algebraic_number_upper :: Ptr Z3_context -> Ptr Z3_ast -> CUInt -> IO (Ptr Z3_ast)
 

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -292,10 +292,17 @@ module Z3.Monad
   , getBoolValue
   , getAstKind
   , isApp
+  , isNumeralAst
+  , isAlgebraicNumber
   , toApp
   , getNumeralString
+  , getNumeralBinaryString
+  , getNumeralDecimalString
+  , getNumeralDouble
   , getNumerator
   , getDenominator
+  , getAlgebraicNumberLower
+  , getAlgebraicNumberUpper
   , simplify
   , simplifyEx
   , getIndexValue
@@ -2096,13 +2103,40 @@ getAstKind = liftFun1 Base.getAstKind
 isApp :: MonadZ3 z3 => AST -> z3 Bool
 isApp = liftFun1 Base.isApp
 
+isNumeralAst ::  MonadZ3 z3 => AST -> z3 Bool
+isNumeralAst = liftFun1 Base.isNumeralAst
+
+-- | Return True if an ast represents an algebraic number, False otherwise.
+isAlgebraicNumber :: MonadZ3 z3 => AST -> z3 Bool
+isAlgebraicNumber = liftFun1 Base.isAlgebraicNumber
+
 -- | Cast AST into an App.
 toApp :: MonadZ3 z3 => AST -> z3 App
 toApp = liftFun1 Base.toApp
 
 -- | Return numeral value, as a string of a numeric constant term.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gae0ffdaa5b0d9c2deb3bbb8d78ac9f4c9>
 getNumeralString :: MonadZ3 z3 => AST -> z3 String
 getNumeralString = liftFun1 Base.getNumeralString
+
+-- | Return numeral value, as a binary string of a numeric constant term.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gae959d9267eb1567887e5ed665a947d5a>
+getNumeralBinaryString :: MonadZ3 z3 => AST -> z3 String
+getNumeralBinaryString = liftFun1 Base.getNumeralBinaryString
+
+-- | Return numeral as a string in decimal notation. The result has at most precision decimal places.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gaf8e1ec34d62bb2c45a8aa7394593d7fb>
+getNumeralDecimalString :: MonadZ3 z3 => AST -> Int -> z3 String
+getNumeralDecimalString = liftFun2 Base.getNumeralDecimalString
+
+-- | Return numeral as a double.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#gaf48e7b61664c0273a4ec77649f0a00cd>
+getNumeralDouble :: MonadZ3 z3 => AST -> z3 Double
+getNumeralDouble = liftFun1 Base.getNumeralDouble
 
 -- | Return the numerator (as a numeral AST) of a numeral AST of sort Real.
 --
@@ -2115,6 +2149,22 @@ getNumerator = liftFun1 Base.getNumerator
 -- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga07549939888e8fdfc8e0fde1776c31a7>
 getDenominator :: MonadZ3 z3 => AST -> z3 AST
 getDenominator = liftFun1 Base.getDenominator
+
+-- | Return a lower bound for the given real algebraic number.
+--   The interval isolating the number is smaller than 1/10^precision.
+--   The result is a numeral AST of sort Real.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga40775ed34e6fcf184b7a0a30deaf2a03>
+getAlgebraicNumberLower :: MonadZ3 z3 => AST -> Int -> z3 AST
+getAlgebraicNumberLower = liftFun2 Base.getAlgebraicNumberLower
+
+-- | Return a upper bound for the given real algebraic number.
+--   The interval isolating the number is smaller than 1/10^precision.
+--   The result is a numeral AST of sort Real.
+--
+-- Reference: <https://z3prover.github.io/api/html/group__capi.html#ga84019f84e6a2e69d3bdfc80441ca0f7d>
+getAlgebraicNumberUpper :: MonadZ3 z3 => AST -> Int -> z3 AST
+getAlgebraicNumberUpper = liftFun2 Base.getAlgebraicNumberUpper
 
 getIndexValue :: MonadZ3 z3 => AST -> z3 Int
 getIndexValue = liftFun1 Base.getIndexValue

--- a/test/Z3/Base/Spec.hs
+++ b/test/Z3/Base/Spec.hs
@@ -99,7 +99,7 @@ spec = around withContext $ do
         upperAst <- Z3.getAlgebraicNumberUpper ctx r 10
         upperDouble <- Z3.getNumeralDouble ctx upperAst
         return (astKind, isNumeral, isAlgebraic, decString, lowerDouble, upperDouble)
-      ) `shouldReturn` (Z3.Z3_APP_AST, True, True, "1.41421?", 1.414213562372879, 1.4142135623733338)
+      ) `shouldReturn` (Z3.Z3_APP_AST, False, True, "1.41421?", 1.414213562372879, 1.4142135623733338)
 
   context "Global Parameters" $ do
     specify "globalParamSet / globalParamGet" $ \_ ->


### PR DESCRIPTION
Add some bindings for getting numeric values.
This is especially useful for getting an approximate value of an AST that is algebraic but not numeric, which results in a crash when attempting to use `getNumeralString`.

Added bindings:
- `isNumeralAst`
- `isAlgebraicNumber`
- `getNumeralBinaryString`
- `getNumeralDecimalString`
- `getNumeralDouble`
- `getAlgebraicNumberLower`
- `getAlgebraicNumberUpper`