### PR TITLE
Add missing binding for mk_seq_nth

### DIFF
--- a/src/Z3/Base.hs
+++ b/src/Z3/Base.hs
@@ -310,6 +310,7 @@ module Z3.Base (
   , mkSeqExtract
   , mkSeqReplace
   , mkSeqAt
+  , mkSeqNth
   , mkSeqLength
   , mkSeqIndex
   , mkStrToInt
@@ -2049,6 +2050,13 @@ mkSeqAt :: Context
         -> AST -- ^ index
         -> IO AST
 mkSeqAt = liftFun2 z3_mk_seq_at
+
+-- | Retrieve from s the element positioned at position index.
+mkSeqNth :: Context
+        -> AST -- ^ s
+        -> AST -- ^ index
+        -> IO AST
+mkSeqNth = liftFun2 z3_mk_seq_nth
 
 -- | Return the length of the sequence s.
 mkSeqLength :: Context

--- a/src/Z3/Monad.hs
+++ b/src/Z3/Monad.hs
@@ -231,6 +231,7 @@ module Z3.Monad
   , mkSeqExtract
   , mkSeqReplace
   , mkSeqAt
+  , mkSeqNth
   , mkSeqLength
   , mkSeqIndex
   , mkStrToInt
@@ -1821,6 +1822,13 @@ mkSeqAt :: MonadZ3 z3
         -> AST -- ^ index
         -> z3 AST
 mkSeqAt = liftFun2 Base.mkSeqAt
+
+-- | Retrieve from s the element positioned at position index.
+mkSeqNth :: MonadZ3 z3
+        => AST -- ^ s
+        -> AST -- ^ index
+        -> z3 AST
+mkSeqNth = liftFun2 Base.mkSeqNth
 
 -- | Return the length of the sequence s.
 mkSeqLength :: MonadZ3 z3 => AST -> z3 AST


### PR DESCRIPTION
Added the `mkSeqNth` function that binds to `mk_seq_nth`. See https://microsoft.github.io/z3guide/docs/theories/Sequences/